### PR TITLE
release: merge develop into main

### DIFF
--- a/Examples/Delphi/RESTful/Horse/README.md
+++ b/Examples/Delphi/RESTful/Horse/README.md
@@ -1,0 +1,59 @@
+# HorseJanus Example
+
+Demonstrates Janus REST/Horse with three scenarios introduced in v2.19+:
+
+1. **Read-only endpoint** — a class decorated with `[RESTReadOnly]` that accepts only GET
+2. **RTTI expand** — master/detail relationship via `$expand`
+3. **VIEW-based JOIN** — a summary view created by `TRESTViewManager` at startup
+
+## Requirements
+
+- Delphi 11+ (Win32 or Win64 VCL)
+- Firebird client (`fbclient.dll`) in the executable directory
+- BOSS package manager for dependencies
+
+## Running
+
+```bash
+# Install dependencies (from the project folder)
+boss install
+
+# Open HorseJanus.dpr in Delphi IDE and run F9, or:
+# Compile and start from the command line
+HorseJanus.exe
+```
+
+The server starts on **port 9000** by default. Press `Enter` to stop.
+
+## Endpoints
+
+| Verb | URL | Notes |
+|------|-----|-------|
+| GET | `/api/Janus/Customer` | List all customers |
+| GET | `/api/Janus/Customer(1)` | Customer by ID |
+| GET | `/api/Janus/Customer?$filter=name eq 'Alice'` | Filter |
+| GET | `/api/Janus/Customer(1)?$expand=Orders` | Expand orders via RTTI |
+| GET | `/api/Janus/CustomerOrderSummary` | VIEW-based aggregated summary |
+| GET | `/api/Janus/ReadOnlyProduct` | Returns data |
+| POST | `/api/Janus/ReadOnlyProduct` | **Blocked** — returns `{"exception":"...read-only (RESTReadOnly)"}` |
+
+## cURL examples
+
+```bash
+# List customers
+curl http://localhost:9000/api/Janus/Customer
+
+# Get with filter
+curl "http://localhost:9000/api/Janus/Customer?\$filter=name eq 'Alice'"
+
+# Expand orders
+curl "http://localhost:9000/api/Janus/Customer(1)?\$expand=Orders"
+
+# View-based join
+curl http://localhost:9000/api/Janus/CustomerOrderSummary
+
+# Test read-only block
+curl -X POST http://localhost:9000/api/Janus/ReadOnlyProduct \
+     -H "Content-Type: application/json" \
+     -d '{"name":"Test","price":1.0}'
+```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Este arquivo registra apenas direcao estrategica, fase atual, milestones proximos e backlog resumido. Historico de release, status operacional por issue, evidencias de teste e reports da pipeline ficam fora deste artefato.
 
-**Ultima atualizacao:** 2026-04-10
+**Ultima atualizacao:** 2026-04-20
 
 ## Visao
 
@@ -53,6 +53,21 @@ Consolidar o Janus como ORM Delphi multi-contexto com evolucao previsivel do nuc
 13. Formalizar a proxima demanda R18.10 como ESP-002 (feature): estabelecer baseline deterministico de validacao pre-gate para freshness de evidencias e isolamento de escopo (diff in-scope vs out-of-scope) antes de `/review`, `/test` e `/develop`.
 14. Formalizar a demanda de correcao R18.11 como ESP-003 (bug): reconciliar explicitamente o diff tracked pre-existente de `ROADMAP.md` para eliminar bloqueio recorrente em `/develop` (`NO_COMMITTABLE_FILES`) com evidencia objetiva de escopo.
 
+### R19 — REST/Horse OData hardening, RESTReadOnly e JOIN via View (em formalizacao)
+
+- Objetivo estrategico: consolidar a camada REST/Horse como base OData testada, com granularidade read-only por classe e alternativa explicita de JOIN via VIEW gerada por FluentSQL + DataEngine.
+- Estado atual: ciclo formalizado por /architect em 2026-04-20; 6 slices definidos; 4 ADRs aprovados; handoff pronto para /task.
+- Demanda ativa: ESP-002 (feature) — cobertura de testes REST/Horse, tokenizacao do parser OData, atributo `[RESTReadOnly]`, `TRESTViewManager` e atualizacao do exemplo `HorseJanus`.
+- Itens da rodada:
+  - [ ] Suite de testes unitarios do parser OData (`TestJanusRESTQueryParse.pas` ≥ 30 cenarios).
+  - [ ] Suite de integracao CRUD Horse + SQLite (`TestJanusRESTHorseIntegration.pas` ≥ 12 cenarios).
+  - [ ] Atributo `[RESTReadOnly]` com cache em `MetaDbDiff` e guard em `TAppResourceBase`.
+  - [ ] Parser OData tokenizado com operadores logicos (and/or/not) e funcoes (contains/startswith/endswith/tolower/toupper).
+  - [ ] Validacao de `$expand` RTTI via teste master/detail.
+  - [ ] Utilitario `TRESTViewManager` para geracao/atualizacao de VIEW via FluentSQL DDL + DataEngine.
+  - [ ] Atualizacao do exemplo `Examples/Delphi/RESTful/Horse/` e documentacao em `docs-src/docs/janus/`.
+- Proxima decisao: apos QA, avaliar expansao para outros web frameworks (DMVC/MARS/WiRL/DataSnap) e Cliente REST.
+
 ## Backlog resumido
 
 - Evolucoes futuras de lazy loading permanecem como backlog exploratorio, com detalhamento tecnico fora deste roadmap.
@@ -85,5 +100,5 @@ Consolidar o Janus como ORM Delphi multi-contexto com evolucao previsivel do nuc
 3. Registre entregas concluidas no changelog, analises em discussoes e execucao da rodada nos artefatos da pipeline.
 4. Se a informacao nao altera prioridade, fase ou direcao do projeto, ela nao deve aumentar o roadmap.
 
-*Ultima atualizacao: 2026-04-10*
+*Ultima atualizacao: 2026-04-20*
 

--- a/Source/Core/Janus.Objects.Helper.pas
+++ b/Source/Core/Janus.Objects.Helper.pas
@@ -56,6 +56,7 @@ type
     function GetTable: Table;
     function GetResource: Resource;
     function GetNotServerUse: NotServerUse;
+    function GetRESTReadOnly: Boolean;
     function GetSubResource: SubResource;
     function &GetType(out AType: TRttiType): Boolean;
     function GetSequence: Sequence;
@@ -73,6 +74,7 @@ var
   GTableCache: TObjectDictionary<String, Table>;
   GSequenceCache: TObjectDictionary<String, Sequence>;
   GNotServerUseCache: TObjectDictionary<String, NotServerUse>;
+  GRESTReadOnlyCache: TDictionary<String, Boolean>;
 
 { TObjectHelper }
 
@@ -92,6 +94,22 @@ begin
 
   Result := NotServerUse.Create;
   GNotServerUseCache.Add(LClassName, Result);
+end;
+
+function TObjectHelper.GetRESTReadOnly: Boolean;
+var
+  LClassName: String;
+begin
+  Result := False;
+  if not Assigned(Self) then
+    Exit;
+
+  LClassName := Self.ClassName;
+  if GRESTReadOnlyCache.TryGetValue(LClassName, Result) then
+    Exit;
+
+  Result := TMappingExplorer.GetRESTReadOnly(Self.ClassType);
+  GRESTReadOnlyCache.Add(LClassName, Result);
 end;
 
 function TObjectHelper.GetResource: Resource;
@@ -282,10 +300,12 @@ initialization
   GTableCache := TObjectDictionary<String, Table>.Create([doOwnsValues]);
   GSequenceCache := TObjectDictionary<String, Sequence>.Create([doOwnsValues]);
   GNotServerUseCache := TObjectDictionary<String, NotServerUse>.Create([doOwnsValues]);
+  GRESTReadOnlyCache := TDictionary<String, Boolean>.Create;
 
 finalization
   GNotServerUseCache.Free;
   GSequenceCache.Free;
   GTableCache.Free;
+  GRESTReadOnlyCache.Free;
 
 end.

--- a/Source/RESTful/Server/Janus.Server.Resource.pas
+++ b/Source/RESTful/Server/Janus.Server.Resource.pas
@@ -44,6 +44,7 @@ type
     const cRESOURCENOTFOUND = '{"exception":"Resource T%s not found!"}';
     const cRESOURCENOTREGISTER = '{"exception":"Resource [%s] not registered on the server!"}';
     const cRESOURCEPERMITION = '{"exception":"Resource [%s] without access permission by the [NotServerUse] attribute!"}';
+    const cRESOURCEREADONLY = '{"exception":"Resource %s is read-only (RESTReadOnly)"}';
     const cEXCEPTIONJSON = '{"exception":"There was an error in trying to convert JSON into the class [%s]!"}';
     const cRESOURCEDELETE = '{"result":"Resource %s delete command executed successfully"}';
     const cRESOURCEINSERT = '{"result":"Resource %s insert command executed successfully", "params":[{%s}]}';
@@ -165,6 +166,10 @@ begin
   LClassType := TMappingExplorer.GetRepositoryMapping.FindEntityByName(AQuery.ResourceName);
   if LClassType = nil then
     Exit;
+
+  if TMappingExplorer.GetRESTReadOnly(LClassType) then
+    raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
   try
     LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
     try
@@ -239,6 +244,9 @@ begin
   if LClassType = nil then
     raise Exception.CreateFmt(cRESOURCENOTREGISTER, [AQuery.ResourceName]);
 
+  if TMappingExplorer.GetRESTReadOnly(LClassType) then
+    raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
   try
     LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
     LObject := LClassType.Create;
@@ -290,6 +298,9 @@ begin
                                 .FindEntityByName(AQuery.ResourceName);
   if LClassType = nil then
     Exit;
+
+  if TMappingExplorer.GetRESTReadOnly(LClassType) then
+    raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
   try
     LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
     LObjectNew := LClassType.Create;

--- a/Source/RESTful/Server/Janus.Server.RestQuery.Parse.pas
+++ b/Source/RESTful/Server/Janus.Server.RestQuery.Parse.pas
@@ -1,11 +1,11 @@
 {
-      ORM Brasil � um ORM simples e descomplicado para quem utiliza Delphi
+      ORM Brasil é um ORM simples e descomplicado para quem utiliza Delphi
 
                    Copyright (c) 2018, Isaque Pinheiro
                           All rights reserved.
 }
 
-{ 
+{
   @abstract(REST Componentes)
   @created(20 Jun 2018)
   @author(Isaque Pinheiro <isaquepsp@gmail.com>)
@@ -29,6 +29,13 @@ uses
   Generics.Collections;
 
 type
+  TFilterTokenKind = (ftkWord, ftkStringLiteral, ftkOther);
+
+  TFilterToken = record
+    Kind: TFilterTokenKind;
+    Value: String;
+  end;
+
   // Querying Data
   TRESTQueryParse = class
   private
@@ -54,6 +61,16 @@ type
     function ParsePathTokens(const APath: String): TArray<String>;
     procedure ParseResourceNameAndID(const AValue: String);
     procedure ParseQueryTokens;
+    // Token-based filter parser (ADR-001)
+    function _TokenizeFilter(const AFilter: String): TArray<TFilterToken>;
+    function _EmitSQL(const ATokens: TArray<TFilterToken>): String;
+    function _ExtractFuncArgTokens(const ATokens: TArray<TFilterToken>;
+      const AStartPos: Integer; out AEndPos: Integer): TArray<TFilterToken>;
+    function _EmitFunctionSQL(const AFuncName: String;
+      const AArgTokens: TArray<TFilterToken>): String;
+    // Reverse: SQL → OData word-boundary safe replacement
+    function _TokenizeSQL(const ASQL: String): TArray<TFilterToken>;
+    function _EmitOData(const ATokens: TArray<TFilterToken>): String;
   protected
     const cPATH_SEPARATOR = '/';
     const cQUERY_SEPARATOR = '&';
@@ -117,7 +134,7 @@ function TRESTQueryParse.GetCount: Boolean;
 begin
   Result := False;
   if FQueryTokens.ContainsKey('$count') then
-    Result := LowerCase(FQueryTokens.Items['$count']) = 'True';
+    Result := LowerCase(FQueryTokens.Items['$count']) = 'true';
 end;
 
 function TRESTQueryParse.GetExpand: String;
@@ -183,7 +200,6 @@ begin
   LQueryingData := ParseQueryingData(FPath);
   FPathTokens := ParsePathTokens(FPath);
   FQuery := ParseOperator(LQueryingData);
-  // Dicion�rio
   ParseQueryTokens;
 end;
 
@@ -195,7 +211,7 @@ begin
   LPos := Pos(cQUERY_INITIAL, AURI);
   if LPos = 0 then
     Exit;
-  Result := Copy(AURI, LPos +1, MaxInt);
+  Result := Copy(AURI, LPos + 1, MaxInt);
 end;
 
 procedure TRESTQueryParse.ParseResourceNameAndID(const AValue: String);
@@ -216,23 +232,19 @@ begin
       '(':
         begin
           FResourceName := LCommand;
-          // Command Next
-          if LFor +1 <= LLength then
-            ParseResourceNameAndID(Copy(AValue, LFor +1, LLength));
+          if LFor + 1 <= LLength then
+            ParseResourceNameAndID(Copy(AValue, LFor + 1, LLength));
           Break;
         end;
       ')':
         begin
           FID := LCommand;
-          // Command Next
-          if LFor +1 <= LLength then
-            ParseResourceNameAndID(Copy(AValue, LFor +1, LLength));
+          if LFor + 1 <= LLength then
+            ParseResourceNameAndID(Copy(AValue, LFor + 1, LLength));
           Break;
         end;
-      '?','$':
-        begin
-          Break;
-        end;
+      '?', '$':
+        Break;
     else
       LCommand := LCommand + LChar;
     end;
@@ -241,46 +253,306 @@ begin
     FResourceName := LCommand;
 end;
 
-function TRESTQueryParse.ParseOperator(const AParams: String): String;
-const
-  LOperatorMapping: array[0..9, 0..1] of String = (('eq', '='),
-                                                   ('ne', '<>'),
-                                                   ('gt', '>'),
-                                                   ('ge', '>='),
-                                                   ('lt', '<'),
-                                                   ('le', '<='),
-                                                   ('add', '+'),
-                                                   ('sub', '-'),
-                                                   ('mul', '*'),
-                                                   ('div', '/'));
+// Tokenize a filter/expression string into words, string-literals, and other chars.
+// Words are letter/digit/underscore sequences starting with a letter or underscore.
+// String literals are single-quoted ('...'), supporting doubled quotes for escaping.
+function TRESTQueryParse._TokenizeFilter(const AFilter: String): TArray<TFilterToken>;
 var
-  LFor: Integer;
+  LResult: TList<TFilterToken>;
+  LToken: TFilterToken;
+  LPos: Integer;
+  LLen: Integer;
+  LStart: Integer;
 begin
-  Result := AParams;
-  for LFor := 0 to High(LOperatorMapping) do
-    Result := StringReplace(Result, LOperatorMapping[LFor, 0],
-                                    LOperatorMapping[LFor, 1], [rfReplaceAll]);
+  LResult := TList<TFilterToken>.Create;
+  try
+    LPos := 1;
+    LLen := Length(AFilter);
+    while LPos <= LLen do
+    begin
+      if AFilter[LPos] = '''' then
+      begin
+        LToken.Kind := ftkStringLiteral;
+        LStart := LPos;
+        Inc(LPos);
+        while LPos <= LLen do
+        begin
+          if AFilter[LPos] = '''' then
+          begin
+            Inc(LPos);
+            if (LPos <= LLen) and (AFilter[LPos] = '''') then
+              Inc(LPos)
+            else
+              Break;
+          end
+          else
+            Inc(LPos);
+        end;
+        LToken.Value := Copy(AFilter, LStart, LPos - LStart);
+        LResult.Add(LToken);
+      end
+      else if CharInSet(AFilter[LPos], ['a'..'z', 'A'..'Z', '_']) then
+      begin
+        LToken.Kind := ftkWord;
+        LStart := LPos;
+        while (LPos <= LLen) and CharInSet(AFilter[LPos], ['a'..'z', 'A'..'Z', '0'..'9', '_']) do
+          Inc(LPos);
+        LToken.Value := Copy(AFilter, LStart, LPos - LStart);
+        LResult.Add(LToken);
+      end
+      else
+      begin
+        LToken.Kind := ftkOther;
+        LToken.Value := AFilter[LPos];
+        LResult.Add(LToken);
+        Inc(LPos);
+      end;
+    end;
+    Result := LResult.ToArray;
+  finally
+    LResult.Free;
+  end;
 end;
 
-function TRESTQueryParse.ParseOperatorReverse(const AParams: String): String;
-const
-  LOperatorMapping: array[0..9, 0..1] of String = (('=','eq'),
-                                                   ('<>','ne'),
-                                                   ('>','gt'),
-                                                   ('>=','ge'),
-                                                   ('<','lt'),
-                                                   ('<=','le'),
-                                                   ('+','add'),
-                                                   ('-','sub'),
-                                                   ('*','mul'),
-                                                   ('/','div'));
+// Extracts tokens enclosed between a '(' and its matching ')'.
+// AStartPos is the index immediately after the opening '(' token.
+// AEndPos is set to the index immediately after the closing ')' token.
+function TRESTQueryParse._ExtractFuncArgTokens(const ATokens: TArray<TFilterToken>;
+  const AStartPos: Integer; out AEndPos: Integer): TArray<TFilterToken>;
 var
-  LFor: Integer;
+  LResult: TList<TFilterToken>;
+  LDepth: Integer;
+  LPos: Integer;
+  LCount: Integer;
 begin
-  Result := AParams;
-  for LFor := 0 to High(LOperatorMapping) do
-    Result := StringReplace(Result, LOperatorMapping[LFor, 0],
-                                    LOperatorMapping[LFor, 1], [rfReplaceAll]);
+  LResult := TList<TFilterToken>.Create;
+  try
+    LDepth := 1;
+    LPos := AStartPos;
+    LCount := Length(ATokens);
+    while (LPos < LCount) and (LDepth > 0) do
+    begin
+      if (ATokens[LPos].Kind = ftkOther) and (ATokens[LPos].Value = '(') then
+        Inc(LDepth)
+      else
+      if (ATokens[LPos].Kind = ftkOther) and (ATokens[LPos].Value = ')') then
+      begin
+        Dec(LDepth);
+        if LDepth = 0 then
+        begin
+          Inc(LPos);
+          Break;
+        end;
+      end;
+      LResult.Add(ATokens[LPos]);
+      Inc(LPos);
+    end;
+    AEndPos := LPos;
+    Result := LResult.ToArray;
+  finally
+    LResult.Free;
+  end;
+end;
+
+// Transforms OData function call (arg tokens) to SQL equivalent.
+// Handles: contains, startswith, endswith → LIKE patterns; tolower, toupper → SQL functions.
+function TRESTQueryParse._EmitFunctionSQL(const AFuncName: String;
+  const AArgTokens: TArray<TFilterToken>): String;
+var
+  LRaw: String;
+  LCommaPos: Integer;
+  LField: String;
+  LValue: String;
+begin
+  // Rebuild raw arg string to extract field and value
+  LRaw := '';
+  for var LArgTok in AArgTokens do
+    LRaw := LRaw + LArgTok.Value;
+
+  if SameText(AFuncName, 'tolower') then
+    Exit('LOWER(' + LRaw + ')');
+  if SameText(AFuncName, 'toupper') then
+    Exit('UPPER(' + LRaw + ')');
+
+  // contains / startswith / endswith — need two arguments: field, value
+  LCommaPos := Pos(',', LRaw);
+  if LCommaPos = 0 then
+    Exit(LRaw);
+
+  LField := Trim(Copy(LRaw, 1, LCommaPos - 1));
+  LValue := Trim(Copy(LRaw, LCommaPos + 1, MaxInt));
+  // Remove surrounding single quotes from value if present
+  if (Length(LValue) >= 2) and (LValue[1] = '''') and (LValue[Length(LValue)] = '''') then
+    LValue := Copy(LValue, 2, Length(LValue) - 2);
+
+  if SameText(AFuncName, 'contains') then
+    Result := LField + ' LIKE ''%' + LValue + '%'''
+  else if SameText(AFuncName, 'startswith') then
+    Result := LField + ' LIKE ''' + LValue + '%'''
+  else if SameText(AFuncName, 'endswith') then
+    Result := LField + ' LIKE ''%' + LValue + ''''
+  else
+    Result := LRaw;
+end;
+
+// Emits SQL from a token list, replacing OData operators and functions.
+// Operators are replaced only when they appear as standalone word tokens,
+// preventing corruption of identifiers that contain operator substrings.
+function TRESTQueryParse._EmitSQL(const ATokens: TArray<TFilterToken>): String;
+const
+  cOpOData: array[0..9] of String  = ('eq','ne','gt','ge','lt','le','add','sub','mul','div');
+  cOpSQL:   array[0..9] of String  = ('=', '<>','>','>=','<','<=','+','-','*','/');
+  cLogOData: array[0..2] of String = ('and','or','not');
+  cLogSQL:   array[0..2] of String = ('AND','OR','NOT');
+  cFuncNames: array[0..4] of String = ('contains','startswith','endswith','tolower','toupper');
+var
+  LResult: TStringBuilder;
+  LPos: Integer;
+  LCount: Integer;
+  LToken: TFilterToken;
+  LMapFor: Integer;
+  LFound: Boolean;
+  LArgTokens: TArray<TFilterToken>;
+  LEndPos: Integer;
+begin
+  LResult := TStringBuilder.Create;
+  try
+    LPos := 0;
+    LCount := Length(ATokens);
+    while LPos < LCount do
+    begin
+      LToken := ATokens[LPos];
+
+      if LToken.Kind = ftkWord then
+      begin
+        // Check for OData function: word followed immediately by '('
+        if (LPos + 1 < LCount) and (ATokens[LPos + 1].Kind = ftkOther) and
+           (ATokens[LPos + 1].Value = '(') then
+        begin
+          LFound := False;
+          for LMapFor := 0 to High(cFuncNames) do
+          begin
+            if SameText(LToken.Value, cFuncNames[LMapFor]) then
+            begin
+              LArgTokens := _ExtractFuncArgTokens(ATokens, LPos + 2, LEndPos);
+              LResult.Append(_EmitFunctionSQL(LToken.Value, LArgTokens));
+              LPos := LEndPos;
+              LFound := True;
+              Break;
+            end;
+          end;
+          if LFound then
+            Continue;
+        end;
+
+        // Check comparison operators
+        LFound := False;
+        for LMapFor := 0 to High(cOpOData) do
+        begin
+          if SameText(LToken.Value, cOpOData[LMapFor]) then
+          begin
+            LResult.Append(cOpSQL[LMapFor]);
+            LFound := True;
+            Break;
+          end;
+        end;
+
+        if not LFound then
+        begin
+          // Check logical operators
+          for LMapFor := 0 to High(cLogOData) do
+          begin
+            if SameText(LToken.Value, cLogOData[LMapFor]) then
+            begin
+              LResult.Append(cLogSQL[LMapFor]);
+              LFound := True;
+              Break;
+            end;
+          end;
+        end;
+
+        if not LFound then
+          LResult.Append(LToken.Value);
+      end
+      else
+        LResult.Append(LToken.Value);
+
+      Inc(LPos);
+    end;
+    Result := LResult.ToString;
+  finally
+    LResult.Free;
+  end;
+end;
+
+// Tokenizes SQL string for reverse mapping back to OData.
+// Reuses the same token structure since SQL identifiers follow the same word rules.
+function TRESTQueryParse._TokenizeSQL(const ASQL: String): TArray<TFilterToken>;
+begin
+  Result := _TokenizeFilter(ASQL);
+end;
+
+// Emits OData from a SQL token list, replacing SQL operators with OData equivalents.
+function TRESTQueryParse._EmitOData(const ATokens: TArray<TFilterToken>): String;
+const
+  // Multi-char SQL operators must be checked before single-char ones
+  cSQLOps:   array[0..9] of String  = ('<>','>=','<=','=','>','<','+','-','*','/');
+  cODataOps: array[0..9] of String  = ('ne','ge','le','eq','gt','lt','add','sub','mul','div');
+var
+  LResult: TStringBuilder;
+  LToken: TFilterToken;
+  LMapFor: Integer;
+  LFound: Boolean;
+begin
+  LResult := TStringBuilder.Create;
+  try
+    for LToken in ATokens do
+    begin
+      if LToken.Kind = ftkOther then
+      begin
+        LFound := False;
+        for LMapFor := 0 to High(cSQLOps) do
+        begin
+          if LToken.Value = cSQLOps[LMapFor] then
+          begin
+            LResult.Append(' ' + cODataOps[LMapFor] + ' ');
+            LFound := True;
+            Break;
+          end;
+        end;
+        if not LFound then
+          LResult.Append(LToken.Value);
+      end
+      else
+        LResult.Append(LToken.Value);
+    end;
+    Result := LResult.ToString;
+  finally
+    LResult.Free;
+  end;
+end;
+
+// ParseOperator converts OData filter expression to SQL using safe word-boundary tokenization.
+// This replaces the legacy StringReplace approach that could corrupt field names (ADR-001).
+function TRESTQueryParse.ParseOperator(const AParams: String): String;
+var
+  LTokens: TArray<TFilterToken>;
+begin
+  if AParams = '' then
+    Exit('');
+  LTokens := _TokenizeFilter(AParams);
+  Result := _EmitSQL(LTokens);
+end;
+
+// ParseOperatorReverse converts SQL expression back to OData format.
+function TRESTQueryParse.ParseOperatorReverse(const AParams: String): String;
+var
+  LTokens: TArray<TFilterToken>;
+begin
+  if AParams = '' then
+    Exit('');
+  LTokens := _TokenizeSQL(AParams);
+  Result := _EmitOData(LTokens);
 end;
 
 function TRESTQueryParse.ParsePathTokens(const APath: String): TArray<String>;

--- a/Source/RESTful/Server/Janus.Server.RestView.Manager.pas
+++ b/Source/RESTful/Server/Janus.Server.RestView.Manager.pas
@@ -1,0 +1,144 @@
+{
+      ORM Brasil é um ORM simples e descomplicado para quem utiliza Delphi
+
+                   Copyright (c) 2018, Isaque Pinheiro
+                          All rights reserved.
+}
+
+{
+  @abstract(REST View Manager)
+  @created(20 Apr 2026)
+  @author(Isaque Pinheiro <isaquepsp@gmail.com>)
+  @abstract(Website : http://www.Janus.com.br)
+
+  Administrative utility that generates or updates database VIEWs at application
+  startup via FluentSQL DDL and DataEngine. Never call EnsureView inside a REST
+  request handler — it is a setup-time operation only (ADR-003).
+}
+
+unit Janus.Server.RestView.Manager;
+
+interface
+
+uses
+  SysUtils,
+  DataEngine.FactoryInterfaces,
+  MetaDbDiff.Mapping.Explorer,
+  FluentSQL,
+  FluentSQL.DDL,
+  FluentSQL.Interfaces;
+
+type
+  TRESTViewManager = class
+  private
+    class function _GetViewName(const AClassType: TClass): String;
+    class function _MapDriverToFluent(const ADriver: TDBEngineDriver): TFluentSQLDriver;
+    class function _SupportsCreateOrReplace(const ADriver: TDBEngineDriver): Boolean;
+    class procedure _ExecuteDDL(const ASQL: String; const AConnection: IDBConnection);
+  public
+    // Creates or replaces the VIEW in the database for the given mapped class.
+    // AClassType must be decorated with [View] and [Table('view_name','')].
+    // ASelect is the IFluentSQL query that defines the view body.
+    // Call only at application startup/setup — never inside a REST handler.
+    class procedure EnsureView(const AClassType: TClass; const ASelect: IFluentSQL;
+      const AConnection: IDBConnection);
+  end;
+
+implementation
+
+uses
+  FluentSQL.Interfaces,
+  MetaDbDiff.Mapping.Classes;
+
+{ TRESTViewManager }
+
+class function TRESTViewManager._GetViewName(const AClassType: TClass): String;
+var
+  LTableMapping: TTableMapping;
+  LViewMapping: TViewMapping;
+begin
+  Result := '';
+  LTableMapping := TMappingExplorer.GetMappingTable(AClassType);
+  if Assigned(LTableMapping) and (LTableMapping.Name <> '') then
+    Exit(LTableMapping.Name);
+
+  LViewMapping := TMappingExplorer.GetMappingView(AClassType);
+  if Assigned(LViewMapping) and (LViewMapping.Name <> '') then
+    Exit(LViewMapping.Name);
+end;
+
+class function TRESTViewManager._MapDriverToFluent(
+  const ADriver: TDBEngineDriver): TFluentSQLDriver;
+begin
+  case ADriver of
+    dnMySQL, dnMariaDB:     Result := dbnMySQL;
+    dnFirebird, dnFirebird3: Result := dbnFirebird;
+    dnInterbase:             Result := dbnInterbase;
+    dnSQLite:                Result := dbnSQLite;
+    dnMSSQL:                 Result := dbnMSSQL;
+    dnOracle:                Result := dbnOracle;
+    dnPostgreSQL:            Result := dbnPostgreSQL;
+    dnDB2:                   Result := dbnDB2;
+  else
+    Result := dbnSQLite;
+  end;
+end;
+
+// Returns True for databases that natively support CREATE OR REPLACE VIEW.
+class function TRESTViewManager._SupportsCreateOrReplace(
+  const ADriver: TDBEngineDriver): Boolean;
+begin
+  Result := ADriver in [dnMySQL, dnMariaDB, dnPostgreSQL, dnOracle];
+end;
+
+class procedure TRESTViewManager._ExecuteDDL(const ASQL: String;
+  const AConnection: IDBConnection);
+begin
+  if ASQL = '' then
+    Exit;
+  AConnection.ExecuteDirect(ASQL);
+end;
+
+class procedure TRESTViewManager.EnsureView(const AClassType: TClass;
+  const ASelect: IFluentSQL; const AConnection: IDBConnection);
+var
+  LViewName: String;
+  LDriver: TDBEngineDriver;
+  LDialect: TFluentSQLDriver;
+  LCreateSQL: String;
+  LDropSQL: String;
+  LSchema: IFluentSchema;
+begin
+  if not Assigned(AClassType) then
+    raise EArgumentNilException.Create('AClassType must not be nil');
+  if not Assigned(ASelect) then
+    raise EArgumentNilException.Create('ASelect must not be nil');
+  if not Assigned(AConnection) then
+    raise EArgumentNilException.Create('AConnection must not be nil');
+
+  LViewName := _GetViewName(AClassType);
+  if LViewName = '' then
+    raise Exception.CreateFmt(
+      'Class %s has no [Table] or [View] attribute with a name — cannot derive view name.',
+      [AClassType.ClassName]);
+
+  LDriver  := AConnection.GetDriver;
+  LDialect := _MapDriverToFluent(LDriver);
+  LSchema  := FluentSQL.Schema(LDialect);
+
+  if _SupportsCreateOrReplace(LDriver) then
+  begin
+    LCreateSQL := LSchema.CreateView(LViewName).OrReplace.&As(ASelect).AsString;
+    _ExecuteDDL(LCreateSQL, AConnection);
+  end
+  else
+  begin
+    // Databases without CREATE OR REPLACE VIEW support (SQLite, Firebird < 3.x, etc.)
+    LDropSQL   := LSchema.DropView(LViewName).IfExists.AsString;
+    LCreateSQL := LSchema.CreateView(LViewName).&As(ASelect).AsString;
+    _ExecuteDDL(LDropSQL, AConnection);
+    _ExecuteDDL(LCreateSQL, AConnection);
+  end;
+end;
+
+end.

--- a/Test/Delphi/JanusRestHorse.dpr
+++ b/Test/Delphi/JanusRestHorse.dpr
@@ -1,0 +1,114 @@
+program JanusRestHorse;
+
+{$IFNDEF TESTINSIGHT}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+{$STRONGLINKTYPES ON}
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.IOUtils,
+  {$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX,
+  {$ENDIF}
+  DUnitX.TestFramework,
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  /// Models
+  MetaDbDiff.Mapping.Register,
+  /// Test Infrastructure
+  RestHorseTest.Models in 'Tests\RestHorseTest.Models.pas',
+  RestHorseTest.Base   in 'Tests\RestHorseTest.Base.pas',
+  /// Integration Test Suites — ESP-002
+  TestJanusRESTHorseIntegration in 'Tests\TestJanusRESTHorseIntegration.pas',
+  TestJanusRESTReadOnly         in 'Tests\TestJanusRESTReadOnly.pas',
+  TestJanusRESTJoinView         in 'Tests\TestJanusRESTJoinView.pas';
+
+const
+  EXIT_SUCCESS = 0;
+  EXIT_FAILURE = 1;
+
+var
+  LRunner: ITestRunner;
+  LResults: IRunResults;
+  LLogger: ITestLogger;
+  LNunitLogger: ITestLogger;
+  LXmlOutputFile: string;
+  LXmlDir: string;
+  LProbeFile: string;
+  LProbeStream: TFileStream;
+  LRunStartTime: TDateTime;
+begin
+{$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX.RunRegisteredTests;
+  Exit;
+{$ENDIF}
+  System.ExitCode := EXIT_FAILURE;
+  try
+    LRunStartTime := Now;
+    TDUnitX.CheckCommandLine;
+    LXmlOutputFile := TDUnitX.Options.XMLOutputFile;
+    if LXmlOutputFile <> '' then
+    begin
+      LXmlOutputFile := TPath.GetFullPath(LXmlOutputFile);
+      LXmlDir := TPath.GetDirectoryName(LXmlOutputFile);
+      if (LXmlDir <> '') and (not TDirectory.Exists(LXmlDir)) then
+        TDirectory.CreateDirectory(LXmlDir);
+      if LXmlDir <> '' then
+      begin
+        LProbeFile := TPath.Combine(LXmlDir, '.janus_rest_horse_write_probe.tmp');
+        LProbeStream := nil;
+        try
+          LProbeStream := TFileStream.Create(LProbeFile, fmCreate);
+        finally
+          FreeAndNil(LProbeStream);
+          if TFile.Exists(LProbeFile) then
+            TFile.Delete(LProbeFile);
+        end;
+      end;
+    end;
+    LRunner := TDUnitX.CreateRunner;
+    LLogger := TDUnitXConsoleLogger.Create(True);
+    LRunner.AddLogger(LLogger);
+    if LXmlOutputFile <> '' then
+      LNunitLogger := TDUnitXXMLNUnitFileLogger.Create(LXmlOutputFile)
+    else
+      LNunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    LRunner.AddLogger(LNunitLogger);
+    LRunner.FailsOnNoAsserts := False;
+    LResults := LRunner.Execute;
+    if LXmlOutputFile <> '' then
+    begin
+      if not TFile.Exists(LXmlOutputFile) then
+      begin
+        System.Writeln('EVIDENCE ERROR: XML artifact was not generated: ' + LXmlOutputFile);
+        System.ExitCode := EXIT_FAILURE;
+        Exit;
+      end;
+      if TFile.GetLastWriteTime(LXmlOutputFile) < LRunStartTime then
+      begin
+        System.Writeln('EVIDENCE ERROR: XML artifact is stale.');
+        System.ExitCode := EXIT_FAILURE;
+        Exit;
+      end;
+    end;
+    if not LResults.AllPassed then
+      System.ExitCode := EXIT_FAILURE
+    else
+      System.ExitCode := EXIT_SUCCESS;
+    {$IFNDEF CI}
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done.. press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+  except
+    on E: Exception do
+    begin
+      System.Writeln(E.ClassName, ': ', E.Message);
+      System.ExitCode := EXIT_FAILURE;
+    end;
+  end;
+end.

--- a/Test/Delphi/JanusSmoke.dpr
+++ b/Test/Delphi/JanusSmoke.dpr
@@ -45,7 +45,9 @@ uses
   TestCriteriaAdvanced in 'Tests\TestCriteriaAdvanced.pas',
   TestMiddlewarePipeline in 'Tests\TestMiddlewarePipeline.pas',
   TestDMLGenerator in 'Tests\TestDMLGenerator.pas',
-  TestFluentSQLIntegration in 'Tests\TestFluentSQLIntegration.pas';
+  TestFluentSQLIntegration in 'Tests\TestFluentSQLIntegration.pas',
+  /// REST/Horse Tests — ESP-002
+  TestJanusRESTQueryParse in 'Tests\TestJanusRESTQueryParse.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/Tests/RestHorseTest.Base.pas
+++ b/Test/Delphi/Tests/RestHorseTest.Base.pas
@@ -1,0 +1,180 @@
+unit RestHorseTest.Base;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  SyncObjs,
+  DUnitX.TestFramework,
+  // DataEngine
+  DataEngine.FactoryInterfaces,
+  DataEngine.FactoryConnection,
+  // FireDAC
+  FireDAC.Comp.Client,
+  FireDAC.Stan.Def,
+  FireDAC.Stan.Intf,
+  FireDAC.Stan.Pool,
+  FireDAC.Stan.Async,
+  FireDAC.UI.Intf,
+  FireDAC.Phys.Intf,
+  FireDAC.Phys.SQLite,
+  FireDAC.Phys.SQLiteDef,
+  // Janus
+  MetaDbDiff.Mapping.Register,
+  Janus.Server.Horse,
+  // Horse
+  Horse;
+
+const
+  cTEST_DB_PATH = 'janus_rest_horse_test.db';
+
+type
+  TRestHorseTestBase = class
+  private
+    FDConnection: TFDConnection;
+    FConnection: IDBConnection;
+    FServer: TRESTServerHorse;
+    FPort: Integer;
+    FServerThread: TThread;
+    procedure _StartHorse;
+    procedure _StopHorse;
+    procedure _CreateSchema;
+    procedure _RegisterTestEntities;
+  protected
+    property Connection: IDBConnection read FConnection;
+    property Port: Integer read FPort;
+    // Executes all pending DDL/DML against the test database
+    procedure ExecuteSQL(const ASQL: String);
+    // Resets the test database to a known clean state
+    procedure ResetDatabase;
+    // Inserts seed data for tests
+    procedure SeedCustomers;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+  end;
+
+implementation
+
+uses
+  DataEngine.FactoryFireDAC,
+  RestHorseTest.Models;
+
+{ TRestHorseTestBase }
+
+procedure TRestHorseTestBase._RegisterTestEntities;
+begin
+  TRegisterClass.RegisterEntity(TCustomerTest);
+  TRegisterClass.RegisterEntity(TOrderTest);
+  TRegisterClass.RegisterEntity(TProductTest);
+  TRegisterClass.RegisterEntity(TCustomerOrderSummary);
+end;
+
+procedure TRestHorseTestBase._CreateSchema;
+const
+  LDDL_CUSTOMER =
+    'CREATE TABLE IF NOT EXISTS customer_test (' +
+    '  id      INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name    VARCHAR(100) NOT NULL,' +
+    '  email   VARCHAR(200),' +
+    '  active  INTEGER DEFAULT 1' +
+    ')';
+  LDDL_ORDER =
+    'CREATE TABLE IF NOT EXISTS order_test (' +
+    '  id          INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  customer_id INTEGER NOT NULL,' +
+    '  description VARCHAR(200),' +
+    '  total       REAL DEFAULT 0' +
+    ')';
+  LDDL_PRODUCT =
+    'CREATE TABLE IF NOT EXISTS product_test (' +
+    '  id    INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name  VARCHAR(100) NOT NULL,' +
+    '  price REAL DEFAULT 0' +
+    ')';
+begin
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS order_test');
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS customer_test');
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS product_test');
+  FConnection.ExecuteDirect(LDDL_CUSTOMER);
+  FConnection.ExecuteDirect(LDDL_ORDER);
+  FConnection.ExecuteDirect(LDDL_PRODUCT);
+end;
+
+procedure TRestHorseTestBase.ResetDatabase;
+begin
+  FConnection.ExecuteDirect('DELETE FROM order_test');
+  FConnection.ExecuteDirect('DELETE FROM customer_test');
+  FConnection.ExecuteDirect('DELETE FROM product_test');
+end;
+
+procedure TRestHorseTestBase.SeedCustomers;
+begin
+  FConnection.ExecuteDirect(
+    'INSERT INTO customer_test (name, email, active) VALUES (''Alice'', ''alice@test.com'', 1)');
+  FConnection.ExecuteDirect(
+    'INSERT INTO customer_test (name, email, active) VALUES (''Bob'', ''bob@test.com'', 1)');
+  FConnection.ExecuteDirect(
+    'INSERT INTO customer_test (name, email, active) VALUES (''Carol'', ''carol@test.com'', 0)');
+end;
+
+procedure TRestHorseTestBase.ExecuteSQL(const ASQL: String);
+begin
+  FConnection.ExecuteDirect(ASQL);
+end;
+
+procedure TRestHorseTestBase._StartHorse;
+begin
+  FPort := 9890 + Random(100);
+  FServer := TRESTServerHorse.Create(nil, FConnection);
+  FServerThread := TThread.CreateAnonymousThread(
+    procedure
+    begin
+      THorse.Listen(FPort);
+    end);
+  FServerThread.FreeOnTerminate := False;
+  FServerThread.Start;
+  Sleep(200);
+end;
+
+procedure TRestHorseTestBase._StopHorse;
+begin
+  THorse.StopListen;
+  if Assigned(FServerThread) then
+  begin
+    FServerThread.Terminate;
+    FServerThread.WaitFor;
+    FreeAndNil(FServerThread);
+  end;
+  FreeAndNil(FServer);
+end;
+
+procedure TRestHorseTestBase.Setup;
+begin
+  Randomize;
+  FDConnection := TFDConnection.Create(nil);
+  FDConnection.Params.DriverID := 'SQLite';
+  FDConnection.Params.Database := cTEST_DB_PATH;
+  FDConnection.Params.Values['OpenMode'] := 'CreateUTF8';
+  FDConnection.Connected := True;
+
+  FConnection := TFactoryFireDAC.Create(FDConnection, dnSQLite);
+  _RegisterTestEntities;
+  _CreateSchema;
+  _StartHorse;
+end;
+
+procedure TRestHorseTestBase.TearDown;
+begin
+  _StopHorse;
+  FConnection := nil;
+  FDConnection.Connected := False;
+  FreeAndNil(FDConnection);
+  if TFile.Exists(cTEST_DB_PATH) then
+    TFile.Delete(cTEST_DB_PATH);
+end;
+
+end.

--- a/Test/Delphi/Tests/RestHorseTest.Models.pas
+++ b/Test/Delphi/Tests/RestHorseTest.Models.pas
@@ -1,0 +1,109 @@
+unit RestHorseTest.Models;
+
+interface
+
+uses
+  DB,
+  MetaDbDiff.Mapping.Attributes;
+
+type
+  // Standard read-write entity for CRUD integration tests
+  [Entity]
+  [Table('customer_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  TCustomerTest = class
+  private
+    FId: Integer;
+    FName: String;
+    FEmail: String;
+    FActive: Boolean;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+
+    [Column('email', ftString, 200)]
+    property Email: String read FEmail write FEmail;
+
+    [Column('active', ftBoolean)]
+    property Active: Boolean read FActive write FActive;
+  end;
+
+  // Detail entity with foreign key to TCustomerTest
+  [Entity]
+  [Table('order_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  TOrderTest = class
+  private
+    FId: Integer;
+    FCustomerId: Integer;
+    FDescription: String;
+    FTotal: Double;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('customer_id', ftInteger)]
+    [ForeignKey('fk_order_customer', 'TCustomerTest', 'id', 'customer_id')]
+    property CustomerId: Integer read FCustomerId write FCustomerId;
+
+    [Column('description', ftString, 200)]
+    property Description: String read FDescription write FDescription;
+
+    [Column('total', ftFloat)]
+    property Total: Double read FTotal write FTotal;
+  end;
+
+  // Read-only entity (RESTReadOnly attribute)
+  [Entity]
+  [Table('product_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTReadOnly]
+  TProductTest = class
+  private
+    FId: Integer;
+    FName: String;
+    FPrice: Double;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+
+    [Column('price', ftFloat)]
+    property Price: Double read FPrice write FPrice;
+  end;
+
+  // View entity — read-only by nature (ADR-002 + ADR-003)
+  [Entity]
+  [View('customer_order_summary', '')]
+  [Table('customer_order_summary', '')]
+  TCustomerOrderSummary = class
+  private
+    FCustomerId: Integer;
+    FCustomerName: String;
+    FOrderCount: Integer;
+    FTotalAmount: Double;
+  public
+    [Column('customer_id', ftInteger)]
+    property CustomerId: Integer read FCustomerId write FCustomerId;
+
+    [Column('customer_name', ftString, 100)]
+    property CustomerName: String read FCustomerName write FCustomerName;
+
+    [Column('order_count', ftInteger)]
+    property OrderCount: Integer read FOrderCount write FOrderCount;
+
+    [Column('total_amount', ftFloat)]
+    property TotalAmount: Double read FTotalAmount write FTotalAmount;
+  end;
+
+implementation
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTHorseIntegration.pas
+++ b/Test/Delphi/Tests/TestJanusRESTHorseIntegration.pas
@@ -1,0 +1,267 @@
+unit TestJanusRESTHorseIntegration;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  Net.HTTPClient,
+  Net.URLClient,
+  DUnitX.TestFramework,
+  RestHorseTest.Base;
+
+type
+  [TestFixture]
+  TTestRESTHorseIntegration = class(TRestHorseTestBase)
+  private
+    FHTTPClient: THTTPClient;
+    function _BuildURL(const AResource: String; const AQuery: String = ''): String;
+    function _Get(const AURL: String): String;
+    function _Post(const AURL: String; const ABody: String): String;
+    function _Put(const AURL: String; const ABody: String): String;
+    function _Delete(const AURL: String): String;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // CA-002 scenarios
+    [Test]
+    procedure GetList_ReturnsJSONArray;
+    [Test]
+    procedure GetByID_ReturnsJSON;
+    [Test]
+    procedure GetWithFilter_EqOperator_ReturnsFiltered;
+    [Test]
+    procedure GetWithOrderBy_ReturnsOrdered;
+    [Test]
+    procedure GetWithTopAndSkip_ReturnsPaged;
+    [Test]
+    procedure GetWithCount_ResponseHasResultCountHeader;
+    [Test]
+    procedure Post_InsertsRecord_Returns200;
+    [Test]
+    procedure Put_UpdatesRecord_Returns200;
+    [Test]
+    procedure Delete_ByID_Returns200;
+    [Test]
+    procedure Delete_WithFilter_Returns200;
+    [Test]
+    procedure Get_UnknownResource_ReturnsErrorJSON;
+    [Test]
+    procedure GetWithAndOrFilter_ReturnsCorrectResult;
+  end;
+
+implementation
+
+const
+  cTIMEOUT_MS = 2000;
+
+{ TTestRESTHorseIntegration }
+
+procedure TTestRESTHorseIntegration.Setup;
+begin
+  inherited Setup;
+  FHTTPClient := THTTPClient.Create;
+  FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
+  FHTTPClient.ResponseTimeout := cTIMEOUT_MS;
+  SeedCustomers;
+end;
+
+procedure TTestRESTHorseIntegration.TearDown;
+begin
+  FreeAndNil(FHTTPClient);
+  inherited TearDown;
+end;
+
+function TTestRESTHorseIntegration._BuildURL(const AResource: String;
+  const AQuery: String): String;
+begin
+  Result := Format('http://localhost:%d/api/Janus/%s', [Port, AResource]);
+  if AQuery <> '' then
+    Result := Result + '?' + AQuery;
+end;
+
+function TTestRESTHorseIntegration._Get(const AURL: String): String;
+var
+  LResponse: IHTTPResponse;
+begin
+  LResponse := FHTTPClient.Get(AURL);
+  Result := LResponse.ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestRESTHorseIntegration._Post(const AURL: String;
+  const ABody: String): String;
+var
+  LStream: TStringStream;
+  LResponse: IHTTPResponse;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    LResponse := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')]);
+    Result := LResponse.ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTHorseIntegration._Put(const AURL: String;
+  const ABody: String): String;
+var
+  LStream: TStringStream;
+  LResponse: IHTTPResponse;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    LResponse := FHTTPClient.Put(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')]);
+    Result := LResponse.ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTHorseIntegration._Delete(const AURL: String): String;
+var
+  LResponse: IHTTPResponse;
+begin
+  LResponse := FHTTPClient.Delete(AURL);
+  Result := LResponse.ContentAsString(TEncoding.UTF8);
+end;
+
+// 1. GET list → 200, JSON array
+procedure TTestRESTHorseIntegration.GetList_ReturnsJSONArray;
+var
+  LURL: String;
+  LResult: String;
+begin
+  LURL := _BuildURL('CustomerTest');
+  LResult := _Get(LURL);
+  Assert.IsNotEmpty(LResult);
+  Assert.StartsWith('[', LResult.Trim);
+end;
+
+// 2. GET by ID → 200, JSON object
+procedure TTestRESTHorseIntegration.GetByID_ReturnsJSON;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest(1)'));
+  Assert.IsNotEmpty(LResult);
+  Assert.IsFalse(LResult.Contains('"exception"'));
+end;
+
+// 3. GET with $filter eq → filtered result
+procedure TTestRESTHorseIntegration.GetWithFilter_EqOperator_ReturnsFiltered;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest', '$filter=name eq ''Alice'''));
+  Assert.Contains(LResult, 'Alice');
+  Assert.IsFalse(LResult.Contains('"exception"'));
+end;
+
+// 4. GET with $orderby
+procedure TTestRESTHorseIntegration.GetWithOrderBy_ReturnsOrdered;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest', '$orderby=name desc'));
+  Assert.IsNotEmpty(LResult);
+  Assert.IsFalse(LResult.Contains('"exception"'));
+end;
+
+// 5. GET with $top and $skip
+procedure TTestRESTHorseIntegration.GetWithTopAndSkip_ReturnsPaged;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest', '$top=1&$skip=1'));
+  Assert.IsNotEmpty(LResult);
+  Assert.IsFalse(LResult.Contains('"exception"'));
+end;
+
+// 6. GET with $count=true → ResultCount header present
+procedure TTestRESTHorseIntegration.GetWithCount_ResponseHasResultCountHeader;
+var
+  LURL: String;
+  LResponse: IHTTPResponse;
+begin
+  LURL := _BuildURL('CustomerTest', '$count=true');
+  LResponse := FHTTPClient.Get(LURL);
+  // The Horse layer adds ResultCount when count > 0
+  Assert.IsNotEmpty(LResponse.ContentAsString(TEncoding.UTF8));
+end;
+
+// 7. POST new record → success JSON
+procedure TTestRESTHorseIntegration.Post_InsertsRecord_Returns200;
+var
+  LResult: String;
+begin
+  ResetDatabase;
+  LResult := _Post(_BuildURL('CustomerTest'),
+    '{"name":"Dave","email":"dave@test.com","active":true}');
+  Assert.IsFalse(LResult.Contains('"exception"'), 'POST returned exception: ' + LResult);
+  Assert.Contains(LResult, 'CustomerTest');
+end;
+
+// 8. PUT updates record → success JSON
+procedure TTestRESTHorseIntegration.Put_UpdatesRecord_Returns200;
+var
+  LResult: String;
+begin
+  _Post(_BuildURL('CustomerTest'),
+    '{"name":"UpdateMe","email":"u@test.com","active":true}');
+  LResult := _Put(_BuildURL('CustomerTest'),
+    '{"id":1,"name":"Updated","email":"upd@test.com","active":true}');
+  Assert.IsFalse(LResult.Contains('"exception"'), 'PUT returned exception: ' + LResult);
+end;
+
+// 9. DELETE by ID path
+procedure TTestRESTHorseIntegration.Delete_ByID_Returns200;
+var
+  LResult: String;
+begin
+  _Post(_BuildURL('CustomerTest'),
+    '{"name":"ToDelete","email":"del@test.com","active":true}');
+  LResult := _Delete(_BuildURL('CustomerTest(1)'));
+  Assert.IsFalse(LResult.Contains('"exception"'), 'DELETE returned exception: ' + LResult);
+end;
+
+// 10. DELETE with $filter
+procedure TTestRESTHorseIntegration.Delete_WithFilter_Returns200;
+var
+  LResult: String;
+begin
+  _Post(_BuildURL('CustomerTest'),
+    '{"name":"Temp","email":"temp@test.com","active":false}');
+  LResult := _Delete(_BuildURL('CustomerTest', '$filter=name eq ''Temp'''));
+  Assert.IsFalse(LResult.Contains('"exception"'), 'DELETE with filter exception: ' + LResult);
+end;
+
+// 11. GET unknown resource → error JSON
+procedure TTestRESTHorseIntegration.Get_UnknownResource_ReturnsErrorJSON;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('NonExistentResource9999'));
+  Assert.Contains(LResult, 'exception');
+end;
+
+// 12. GET with AND/OR filter — validates parser ↔ execution integration
+procedure TTestRESTHorseIntegration.GetWithAndOrFilter_ReturnsCorrectResult;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest',
+    '$filter=name eq ''Alice'' or name eq ''Bob'''));
+  Assert.IsFalse(LResult.Contains('"exception"'), 'AND/OR filter exception: ' + LResult);
+  Assert.Contains(LResult, 'Alice');
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestRESTHorseIntegration);
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTJoinView.pas
+++ b/Test/Delphi/Tests/TestJanusRESTJoinView.pas
@@ -1,0 +1,206 @@
+unit TestJanusRESTJoinView;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  Net.HTTPClient,
+  Net.URLClient,
+  DUnitX.TestFramework,
+  // FluentSQL
+  FluentSQL,
+  // Janus
+  Janus.Server.RestView.Manager,
+  RestHorseTest.Base,
+  RestHorseTest.Models;
+
+type
+  [TestFixture]
+  TTestRESTJoinView = class(TRestHorseTestBase)
+  private
+    FHTTPClient: THTTPClient;
+    function _BuildURL(const AResource: String; const AQuery: String = ''): String;
+    function _Get(const AURL: String): String;
+    function _Post(const AURL: String; const ABody: String): String;
+    function _Delete(const AURL: String): String;
+    procedure _SeedOrderData;
+    procedure _CreateSummaryView;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // CA-005: $expand via RTTI
+    [Test]
+    procedure Expand_MasterDetail_ReturnsRelatedData;
+    [Test]
+    procedure Expand_EmptyAssociation_ReturnsCustomerWithEmptyList;
+
+    // CA-006: VIEW via FluentSQL + DataEngine
+    [Test]
+    procedure EnsureView_CreatesView_NoException;
+    [Test]
+    procedure EnsureView_Idempotent_SecondCallNoException;
+    [Test]
+    procedure Get_ViewResource_ReturnsData;
+    [Test]
+    procedure Post_ViewResource_ReturnsReadOnlyError;
+  end;
+
+implementation
+
+const
+  cTIMEOUT_MS = 2000;
+  cREADONLY_MSG = 'read-only (RESTReadOnly)';
+
+{ TTestRESTJoinView }
+
+procedure TTestRESTJoinView.Setup;
+begin
+  inherited Setup;
+  FHTTPClient := THTTPClient.Create;
+  FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
+  FHTTPClient.ResponseTimeout := cTIMEOUT_MS;
+  _SeedOrderData;
+end;
+
+procedure TTestRESTJoinView.TearDown;
+begin
+  FreeAndNil(FHTTPClient);
+  inherited TearDown;
+end;
+
+function TTestRESTJoinView._BuildURL(const AResource: String;
+  const AQuery: String): String;
+begin
+  Result := Format('http://localhost:%d/api/Janus/%s', [Port, AResource]);
+  if AQuery <> '' then
+    Result := Result + '?' + AQuery;
+end;
+
+function TTestRESTJoinView._Get(const AURL: String): String;
+begin
+  Result := FHTTPClient.Get(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestRESTJoinView._Post(const AURL: String; const ABody: String): String;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')])
+      .ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTJoinView._Delete(const AURL: String): String;
+begin
+  Result := FHTTPClient.Delete(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+procedure TTestRESTJoinView._SeedOrderData;
+begin
+  SeedCustomers;
+  ExecuteSQL(
+    'INSERT INTO order_test (customer_id, description, total) VALUES (1, ''Order A'', 100.00)');
+  ExecuteSQL(
+    'INSERT INTO order_test (customer_id, description, total) VALUES (1, ''Order B'', 200.00)');
+  ExecuteSQL(
+    'INSERT INTO order_test (customer_id, description, total) VALUES (2, ''Order C'', 50.00)');
+end;
+
+procedure TTestRESTJoinView._CreateSummaryView;
+var
+  LSelect: IFluentSQL;
+begin
+  LSelect := FluentSQL.Query(dbnSQLite)
+    .Select(['c.id AS customer_id',
+             'c.name AS customer_name',
+             'COUNT(o.id) AS order_count',
+             'COALESCE(SUM(o.total), 0) AS total_amount'])
+    .From('customer_test c')
+    .LeftJoin('order_test o', 'o.customer_id = c.id')
+    .GroupBy(['c.id', 'c.name']);
+
+  TRESTViewManager.EnsureView(TCustomerOrderSummary, LSelect, Connection);
+end;
+
+// CA-005 Test 1: $expand returns master + detail
+procedure TTestRESTJoinView.Expand_MasterDetail_ReturnsRelatedData;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest(1)', '$expand=OrderTest'));
+  Assert.IsFalse(LResult.Contains('"exception"'),
+    '$expand returned exception: ' + LResult);
+end;
+
+// CA-005 Test 2: $expand with customer with no orders still returns customer
+procedure TTestRESTJoinView.Expand_EmptyAssociation_ReturnsCustomerWithEmptyList;
+var
+  LResult: String;
+begin
+  // Customer 3 (Carol) has no orders
+  LResult := _Get(_BuildURL('CustomerTest(3)', '$expand=OrderTest'));
+  Assert.IsFalse(LResult.Contains('"exception"'),
+    '$expand empty list returned exception: ' + LResult);
+end;
+
+// CA-006 Test 1: EnsureView creates the VIEW without exception
+procedure TTestRESTJoinView.EnsureView_CreatesView_NoException;
+begin
+  Assert.WillNotRaise(
+    procedure
+    begin
+      _CreateSummaryView;
+    end,
+    Exception,
+    'EnsureView should not raise');
+end;
+
+// CA-006 Test 2: calling EnsureView again (idempotent) does not raise
+procedure TTestRESTJoinView.EnsureView_Idempotent_SecondCallNoException;
+begin
+  _CreateSummaryView;
+  Assert.WillNotRaise(
+    procedure
+    begin
+      _CreateSummaryView;
+    end,
+    Exception,
+    'Second EnsureView call should not raise');
+end;
+
+// CA-006 Test 3: GET on view resource returns data
+procedure TTestRESTJoinView.Get_ViewResource_ReturnsData;
+var
+  LResult: String;
+begin
+  _CreateSummaryView;
+  LResult := _Get(_BuildURL('CustomerOrderSummary'));
+  Assert.IsFalse(LResult.Contains('"exception"'),
+    'GET view resource returned exception: ' + LResult);
+end;
+
+// CA-006 Test 4: POST on view resource must be blocked
+procedure TTestRESTJoinView.Post_ViewResource_ReturnsReadOnlyError;
+var
+  LResult: String;
+begin
+  _CreateSummaryView;
+  LResult := _Post(_BuildURL('CustomerOrderSummary'),
+    '{"customer_id":1,"customer_name":"Test","order_count":0,"total_amount":0}');
+  Assert.Contains(LResult, cREADONLY_MSG,
+    'POST on view must return read-only error, got: ' + LResult);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestRESTJoinView);
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTQueryParse.pas
+++ b/Test/Delphi/Tests/TestJanusRESTQueryParse.pas
@@ -1,0 +1,452 @@
+unit TestJanusRESTQueryParse;
+
+interface
+
+uses
+  SysUtils,
+  DUnitX.TestFramework,
+  Janus.Server.RestQuery.Parse;
+
+type
+  [TestFixture]
+  TTestRESTQueryParse = class
+  private
+    FParser: TRESTQueryParse;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // --- ParseResourceNameAndID ---
+    [Test]
+    procedure ParseResourceName_Simple;
+    [Test]
+    procedure ParseResourceName_WithID;
+    [Test]
+    procedure ParseResourceName_WithQueryString;
+    [Test]
+    procedure ParseResourceName_IDIsEmpty_WhenNoParens;
+    [Test]
+    procedure ParseResourceName_PrefixedWithT;
+
+    // --- ParseOperator: comparison operators (word-boundary safe) ---
+    [Test]
+    procedure ParseOperator_Eq_Converted;
+    [Test]
+    procedure ParseOperator_Ne_Converted;
+    [Test]
+    procedure ParseOperator_Gt_Converted;
+    [Test]
+    procedure ParseOperator_Ge_Converted;
+    [Test]
+    procedure ParseOperator_Lt_Converted;
+    [Test]
+    procedure ParseOperator_Le_Converted;
+    [Test]
+    procedure ParseOperator_Add_Converted;
+    [Test]
+    procedure ParseOperator_Sub_Converted;
+    [Test]
+    procedure ParseOperator_Mul_Converted;
+    [Test]
+    procedure ParseOperator_Div_Converted;
+
+    // --- ParseOperator: field names containing operator substrings (regression) ---
+    [Test]
+    procedure ParseOperator_FieldNameWithEqSubstring_NotCorrupted;
+    [Test]
+    procedure ParseOperator_FieldNameWithLeSubstring_NotCorrupted;
+    [Test]
+    procedure ParseOperator_FieldNameWithAddSubstring_NotCorrupted;
+
+    // --- ParseOperator: logical operators ---
+    [Test]
+    procedure ParseOperator_And_Converted;
+    [Test]
+    procedure ParseOperator_Or_Converted;
+    [Test]
+    procedure ParseOperator_Not_Converted;
+    [Test]
+    procedure ParseOperator_CombinedAndOr;
+
+    // --- ParseOperator: OData functions ---
+    [Test]
+    procedure ParseOperator_Contains_Converted;
+    [Test]
+    procedure ParseOperator_Startswith_Converted;
+    [Test]
+    procedure ParseOperator_Endswith_Converted;
+    [Test]
+    procedure ParseOperator_Tolower_Converted;
+    [Test]
+    procedure ParseOperator_Toupper_Converted;
+
+    // --- ParseOperator: string literals pass through unchanged ---
+    [Test]
+    procedure ParseOperator_StringLiteral_NotAltered;
+    [Test]
+    procedure ParseOperator_StringLiteralWithOperatorWord_NotAltered;
+
+    // --- ParseOperator: parentheses pass through ---
+    [Test]
+    procedure ParseOperator_ParenthesesPassThrough;
+
+    // --- ParseQuery: full URI tokenization ---
+    [Test]
+    procedure ParseQuery_ExtractsFilter;
+    [Test]
+    procedure ParseQuery_ExtractsTop;
+    [Test]
+    procedure ParseQuery_ExtractsSkip;
+    [Test]
+    procedure ParseQuery_ExtractsOrderBy;
+    [Test]
+    procedure ParseQuery_ExtractsCount;
+    [Test]
+    procedure ParseQuery_ExtractsExpand;
+    [Test]
+    procedure ParseQuery_NoQueryString;
+
+    // --- Setters ---
+    [Test]
+    procedure SetFilter_AppliesOperatorConversion;
+    [Test]
+    procedure SetTop_StoresValue;
+    [Test]
+    procedure SetSkip_StoresValue;
+    [Test]
+    procedure SetCount_StoresValue;
+    [Test]
+    procedure SetOrderBy_StoresValue;
+    [Test]
+    procedure SetExpand_StoresValue;
+    [Test]
+    procedure SetSelect_StoresValue;
+  end;
+
+implementation
+
+procedure TTestRESTQueryParse.Setup;
+begin
+  FParser := TRESTQueryParse.Create;
+end;
+
+procedure TTestRESTQueryParse.TearDown;
+begin
+  FParser.Free;
+end;
+
+// --- ParseResourceNameAndID ---
+
+procedure TTestRESTQueryParse.ParseResourceName_Simple;
+begin
+  FParser.ParseQuery('/api/Janus/Customer');
+  Assert.AreEqual('TCustomer', FParser.ResourceName);
+end;
+
+procedure TTestRESTQueryParse.ParseResourceName_WithID;
+begin
+  FParser.ParseQuery('/api/Janus/Customer(42)');
+  Assert.AreEqual('TCustomer', FParser.ResourceName);
+  Assert.AreEqual('42', FParser.ID.ToString);
+end;
+
+procedure TTestRESTQueryParse.ParseResourceName_WithQueryString;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$top=10');
+  Assert.AreEqual('TCustomer', FParser.ResourceName);
+end;
+
+procedure TTestRESTQueryParse.ParseResourceName_IDIsEmpty_WhenNoParens;
+begin
+  FParser.ParseQuery('/api/Janus/Customer');
+  Assert.IsTrue(FParser.ID.IsEmpty);
+end;
+
+procedure TTestRESTQueryParse.ParseResourceName_PrefixedWithT;
+begin
+  FParser.ParseQuery('Order');
+  Assert.AreEqual('TOrder', FParser.ResourceName);
+end;
+
+// --- Comparison operators ---
+
+procedure TTestRESTQueryParse.ParseOperator_Eq_Converted;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$filter=name eq ''Alice''');
+  Assert.Contains(FParser.Filter, '=');
+  Assert.IsFalse(FParser.Filter.Contains(' eq '));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Ne_Converted;
+begin
+  FParser.SetFilter('status ne ''active''');
+  Assert.Contains(FParser.Filter, '<>');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Gt_Converted;
+begin
+  FParser.SetFilter('age gt 18');
+  Assert.Contains(FParser.Filter, '>');
+  Assert.IsFalse(FParser.Filter.Contains(' gt '));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Ge_Converted;
+begin
+  FParser.SetFilter('score ge 90');
+  Assert.Contains(FParser.Filter, '>=');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Lt_Converted;
+begin
+  FParser.SetFilter('price lt 100');
+  Assert.Contains(FParser.Filter, '<');
+  Assert.IsFalse(FParser.Filter.Contains(' lt '));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Le_Converted;
+begin
+  FParser.SetFilter('price le 100');
+  Assert.Contains(FParser.Filter, '<=');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Add_Converted;
+begin
+  FParser.SetFilter('qty add 1');
+  Assert.Contains(FParser.Filter, '+');
+  Assert.IsFalse(FParser.Filter.Contains(' add '));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Sub_Converted;
+begin
+  FParser.SetFilter('qty sub 1');
+  Assert.Contains(FParser.Filter, '-');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Mul_Converted;
+begin
+  FParser.SetFilter('qty mul price');
+  Assert.Contains(FParser.Filter, '*');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Div_Converted;
+begin
+  FParser.SetFilter('total div qty');
+  Assert.Contains(FParser.Filter, '/');
+end;
+
+// --- Field-name regression tests ---
+
+procedure TTestRESTQueryParse.ParseOperator_FieldNameWithEqSubstring_NotCorrupted;
+begin
+  // "sequence" contains no "eq" as standalone token — must not be altered
+  FParser.SetFilter('sequence eq 5');
+  Assert.AreEqual('sequence = 5', FParser.Filter);
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_FieldNameWithLeSubstring_NotCorrupted;
+begin
+  // "delete_date" contains "le" inside "delete" — must not be altered
+  FParser.SetFilter('delete_date lt ''2025-01-01''');
+  Assert.AreEqual('delete_date < ''2025-01-01''', FParser.Filter);
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_FieldNameWithAddSubstring_NotCorrupted;
+begin
+  // "address" contains "add" inside it — must not be replaced
+  FParser.SetFilter('address eq ''Main St''');
+  Assert.AreEqual('address = ''Main St''', FParser.Filter);
+end;
+
+// --- Logical operators ---
+
+procedure TTestRESTQueryParse.ParseOperator_And_Converted;
+begin
+  FParser.SetFilter('name eq ''Alice'' and age gt 18');
+  Assert.Contains(FParser.Filter, 'AND');
+  Assert.IsFalse(FParser.Filter.Contains(' and '));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Or_Converted;
+begin
+  FParser.SetFilter('status eq ''active'' or status eq ''pending''');
+  Assert.Contains(FParser.Filter, 'OR');
+  Assert.IsFalse(FParser.Filter.Contains(' or '));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Not_Converted;
+begin
+  FParser.SetFilter('not (active eq false)');
+  Assert.Contains(FParser.Filter, 'NOT');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_CombinedAndOr;
+begin
+  FParser.SetFilter('(a eq 1 and b gt 2) or (c lt 10)');
+  Assert.Contains(FParser.Filter, 'AND');
+  Assert.Contains(FParser.Filter, 'OR');
+  Assert.Contains(FParser.Filter, '=');
+  Assert.Contains(FParser.Filter, '>');
+  Assert.Contains(FParser.Filter, '<');
+end;
+
+// --- OData functions ---
+
+procedure TTestRESTQueryParse.ParseOperator_Contains_Converted;
+begin
+  FParser.SetFilter('contains(name,''Alice'')');
+  Assert.Contains(FParser.Filter, 'LIKE');
+  Assert.Contains(FParser.Filter, '%Alice%');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Startswith_Converted;
+begin
+  FParser.SetFilter('startswith(name,''Al'')');
+  Assert.Contains(FParser.Filter, 'LIKE');
+  Assert.Contains(FParser.Filter, 'Al%');
+  Assert.IsFalse(FParser.Filter.Contains('%Al%'));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Endswith_Converted;
+begin
+  FParser.SetFilter('endswith(name,''ice'')');
+  Assert.Contains(FParser.Filter, 'LIKE');
+  Assert.Contains(FParser.Filter, '%ice');
+  // Must not start with % before 'ice%' (that would be contains)
+  Assert.IsFalse(FParser.Filter.Contains('%ice%'));
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Tolower_Converted;
+begin
+  FParser.SetFilter('tolower(name) eq ''alice''');
+  Assert.Contains(FParser.Filter, 'LOWER(name)');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_Toupper_Converted;
+begin
+  FParser.SetFilter('toupper(status) eq ''ACTIVE''');
+  Assert.Contains(FParser.Filter, 'UPPER(status)');
+end;
+
+// --- String literals ---
+
+procedure TTestRESTQueryParse.ParseOperator_StringLiteral_NotAltered;
+begin
+  // Operator words inside string literals must not be transformed
+  FParser.SetFilter('note eq ''add more eq content''');
+  // The string 'add more eq content' should appear verbatim
+  Assert.Contains(FParser.Filter, '''add more eq content''');
+end;
+
+procedure TTestRESTQueryParse.ParseOperator_StringLiteralWithOperatorWord_NotAltered;
+begin
+  FParser.SetFilter('code eq ''eq-001''');
+  Assert.Contains(FParser.Filter, '''eq-001''');
+end;
+
+// --- Parentheses ---
+
+procedure TTestRESTQueryParse.ParseOperator_ParenthesesPassThrough;
+begin
+  FParser.SetFilter('(name eq ''Alice'') and (age gt 18)');
+  Assert.StartsWith('(', FParser.Filter);
+  Assert.Contains(FParser.Filter, 'AND');
+end;
+
+// --- ParseQuery full URI ---
+
+procedure TTestRESTQueryParse.ParseQuery_ExtractsFilter;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$filter=name eq ''Alice''&$top=5');
+  Assert.AreNotEqual('', FParser.Filter);
+  Assert.Contains(FParser.Filter, '=');
+end;
+
+procedure TTestRESTQueryParse.ParseQuery_ExtractsTop;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$top=25');
+  Assert.AreEqual(25, FParser.Top);
+end;
+
+procedure TTestRESTQueryParse.ParseQuery_ExtractsSkip;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$top=10&$skip=20');
+  Assert.AreEqual(20, FParser.Skip);
+end;
+
+procedure TTestRESTQueryParse.ParseQuery_ExtractsOrderBy;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$orderby=name asc');
+  Assert.AreEqual('name asc', FParser.OrderBy);
+end;
+
+procedure TTestRESTQueryParse.ParseQuery_ExtractsCount;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$count=true');
+  Assert.IsTrue(FParser.Count);
+end;
+
+procedure TTestRESTQueryParse.ParseQuery_ExtractsExpand;
+begin
+  FParser.ParseQuery('/api/Janus/Customer?$expand=Orders');
+  Assert.AreEqual('Orders', FParser.Expand);
+end;
+
+procedure TTestRESTQueryParse.ParseQuery_NoQueryString;
+begin
+  FParser.ParseQuery('/api/Janus/Customer');
+  Assert.AreEqual('', FParser.Filter);
+  Assert.AreEqual(0, FParser.Top);
+  Assert.AreEqual(0, FParser.Skip);
+  Assert.IsFalse(FParser.Count);
+end;
+
+// --- Setters ---
+
+procedure TTestRESTQueryParse.SetFilter_AppliesOperatorConversion;
+begin
+  FParser.SetFilter('qty gt 0');
+  Assert.Contains(FParser.Filter, '>');
+end;
+
+procedure TTestRESTQueryParse.SetTop_StoresValue;
+begin
+  FParser.SetTop(TValue.From<Integer>(50));
+  Assert.AreEqual(50, FParser.Top);
+end;
+
+procedure TTestRESTQueryParse.SetSkip_StoresValue;
+begin
+  FParser.SetSkip(TValue.From<Integer>(10));
+  Assert.AreEqual(10, FParser.Skip);
+end;
+
+procedure TTestRESTQueryParse.SetCount_StoresValue;
+begin
+  FParser.SetCount(TValue.From<String>('true'));
+  Assert.IsTrue(FParser.Count);
+end;
+
+procedure TTestRESTQueryParse.SetOrderBy_StoresValue;
+begin
+  FParser.SetOrderBy('name desc');
+  Assert.AreEqual('name desc', FParser.OrderBy);
+end;
+
+procedure TTestRESTQueryParse.SetExpand_StoresValue;
+begin
+  FParser.SetExpand('Orders');
+  Assert.AreEqual('Orders', FParser.Expand);
+end;
+
+procedure TTestRESTQueryParse.SetSelect_StoresValue;
+begin
+  FParser.SetSelect('id,name,email');
+  Assert.AreEqual('id,name,email', FParser.Select);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestRESTQueryParse);
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTReadOnly.pas
+++ b/Test/Delphi/Tests/TestJanusRESTReadOnly.pas
@@ -1,0 +1,173 @@
+unit TestJanusRESTReadOnly;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  Net.HTTPClient,
+  Net.URLClient,
+  DUnitX.TestFramework,
+  MetaDbDiff.Mapping.Explorer,
+  RestHorseTest.Base,
+  RestHorseTest.Models;
+
+type
+  [TestFixture]
+  TTestRESTReadOnly = class(TRestHorseTestBase)
+  private
+    FHTTPClient: THTTPClient;
+    function _BuildURL(const AResource: String; const AQuery: String = ''): String;
+    function _Get(const AURL: String): String;
+    function _Post(const AURL: String; const ABody: String): String;
+    function _Put(const AURL: String; const ABody: String): String;
+    function _Delete(const AURL: String): String;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // CA-003 unit-level tests
+    [Test]
+    procedure GetRESTReadOnly_ClassWithoutAttribute_ReturnsFalse;
+    [Test]
+    procedure GetRESTReadOnly_ClassWithAttribute_ReturnsTrue;
+
+    // CA-003 integration-level tests
+    [Test]
+    procedure Get_ReadOnlyResource_Succeeds;
+    [Test]
+    procedure Post_ReadOnlyResource_ReturnsReadOnlyError;
+    [Test]
+    procedure Put_ReadOnlyResource_ReturnsReadOnlyError;
+    [Test]
+    procedure Delete_ReadOnlyResource_ReturnsReadOnlyError;
+  end;
+
+implementation
+
+const
+  cTIMEOUT_MS = 2000;
+  cREADONLY_MSG = 'read-only (RESTReadOnly)';
+
+{ TTestRESTReadOnly }
+
+procedure TTestRESTReadOnly.Setup;
+begin
+  inherited Setup;
+  FHTTPClient := THTTPClient.Create;
+  FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
+  FHTTPClient.ResponseTimeout := cTIMEOUT_MS;
+end;
+
+procedure TTestRESTReadOnly.TearDown;
+begin
+  FreeAndNil(FHTTPClient);
+  inherited TearDown;
+end;
+
+function TTestRESTReadOnly._BuildURL(const AResource: String;
+  const AQuery: String): String;
+begin
+  Result := Format('http://localhost:%d/api/Janus/%s', [Port, AResource]);
+  if AQuery <> '' then
+    Result := Result + '?' + AQuery;
+end;
+
+function TTestRESTReadOnly._Get(const AURL: String): String;
+begin
+  Result := FHTTPClient.Get(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestRESTReadOnly._Post(const AURL: String; const ABody: String): String;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')])
+      .ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTReadOnly._Put(const AURL: String; const ABody: String): String;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Put(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')])
+      .ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTReadOnly._Delete(const AURL: String): String;
+begin
+  Result := FHTTPClient.Delete(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+// Unit: class without [RESTReadOnly] → False
+procedure TTestRESTReadOnly.GetRESTReadOnly_ClassWithoutAttribute_ReturnsFalse;
+begin
+  Assert.IsFalse(TMappingExplorer.GetRESTReadOnly(TCustomerTest));
+end;
+
+// Unit: class with [RESTReadOnly] → True
+procedure TTestRESTReadOnly.GetRESTReadOnly_ClassWithAttribute_ReturnsTrue;
+begin
+  Assert.IsTrue(TMappingExplorer.GetRESTReadOnly(TProductTest));
+end;
+
+// Integration: GET on read-only resource must succeed (SELECT is never blocked)
+procedure TTestRESTReadOnly.Get_ReadOnlyResource_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('ProductTest'));
+  Assert.IsFalse(LResult.Contains(cREADONLY_MSG),
+    'GET should not return read-only error but got: ' + LResult);
+end;
+
+// Integration: POST on read-only resource must return error JSON
+procedure TTestRESTReadOnly.Post_ReadOnlyResource_ReturnsReadOnlyError;
+var
+  LResult: String;
+begin
+  LResult := _Post(_BuildURL('ProductTest'),
+    '{"name":"Blocked","price":9.99}');
+  Assert.Contains(LResult, cREADONLY_MSG,
+    'POST on read-only resource must return read-only error, got: ' + LResult);
+end;
+
+// Integration: PUT on read-only resource must return error JSON
+procedure TTestRESTReadOnly.Put_ReadOnlyResource_ReturnsReadOnlyError;
+var
+  LResult: String;
+begin
+  LResult := _Put(_BuildURL('ProductTest'),
+    '{"id":1,"name":"Blocked","price":9.99}');
+  Assert.Contains(LResult, cREADONLY_MSG,
+    'PUT on read-only resource must return read-only error, got: ' + LResult);
+end;
+
+// Integration: DELETE on read-only resource must return error JSON
+procedure TTestRESTReadOnly.Delete_ReadOnlyResource_ReturnsReadOnlyError;
+var
+  LResult: String;
+begin
+  LResult := _Delete(_BuildURL('ProductTest(1)'));
+  Assert.Contains(LResult, cREADONLY_MSG,
+    'DELETE on read-only resource must return read-only error, got: ' + LResult);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestRESTReadOnly);
+
+end.

--- a/docs-src/docs/janus/odata-reference.md
+++ b/docs-src/docs/janus/odata-reference.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 10
+---
+
+# OData Query Reference
+
+Janus REST/Horse exposes OData v4-compatible query parameters over any mapped Delphi class.
+
+## Supported query parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `$filter` | WHERE clause equivalent | `$filter=name eq 'Alice'` |
+| `$orderby` | ORDER BY clause | `$orderby=name desc` |
+| `$top` | Limit results (page size) | `$top=25` |
+| `$skip` | Offset (used with `$top`) | `$skip=50` |
+| `$count` | Returns record count in `ResultCount` header | `$count=true` |
+| `$select` | Projections (column subset) | `$select=id,name` |
+| `$expand` | Eager-load associations via RTTI | `$expand=Orders` |
+| `$search` | Full-text style filter | `$search=Alice` |
+
+## Comparison operators
+
+| OData | SQL equivalent | Example |
+|-------|---------------|---------|
+| `eq` | `=` | `name eq 'Alice'` |
+| `ne` | `<>` | `status ne 'inactive'` |
+| `gt` | `>` | `age gt 18` |
+| `ge` | `>=` | `score ge 90` |
+| `lt` | `<` | `price lt 100` |
+| `le` | `<=` | `discount le 0.5` |
+| `add` | `+` | `qty add 1` |
+| `sub` | `-` | `total sub tax` |
+| `mul` | `*` | `price mul qty` |
+| `div` | `/` | `total div count` |
+
+> **Word-boundary safe:** operators are only replaced when they appear as complete words. A field named `sequence`, `address`, or `delete_date` is never corrupted by the parser (ADR-001).
+
+## Logical operators
+
+| OData | SQL | Example |
+|-------|-----|---------|
+| `and` | `AND` | `active eq true and age gt 18` |
+| `or` | `OR` | `status eq 'a' or status eq 'b'` |
+| `not` | `NOT` | `not (active eq false)` |
+
+Parentheses are passed through to SQL unchanged, allowing complex expressions:
+
+```
+$filter=(name eq 'Alice' and age gt 18) or status eq 'vip'
+```
+
+## OData functions
+
+| OData function | SQL equivalent | Example |
+|----------------|---------------|---------|
+| `contains(field,'x')` | `field LIKE '%x%'` | `contains(name,'ali')` |
+| `startswith(field,'x')` | `field LIKE 'x%'` | `startswith(code,'INV')` |
+| `endswith(field,'x')` | `field LIKE '%x'` | `endswith(email,'@corp.com')` |
+| `tolower(field)` | `LOWER(field)` | `tolower(name) eq 'alice'` |
+| `toupper(field)` | `UPPER(field)` | `toupper(status) eq 'ACTIVE'` |
+
+## Pagination example
+
+```
+GET /api/Janus/Customer?$top=10&$skip=20&$orderby=name asc&$count=true
+```
+
+Returns records 21–30 ordered by name, and includes the total count in the `ResultCount` response header.
+
+## cURL examples
+
+```bash
+# Filter by name
+curl "http://localhost:9000/api/Janus/Customer?\$filter=name eq 'Alice'"
+
+# Pagination
+curl "http://localhost:9000/api/Janus/Customer?\$top=10&\$skip=0"
+
+# Contains function
+curl "http://localhost:9000/api/Janus/Customer?\$filter=contains(email,'@corp.com')"
+
+# Expand related data
+curl "http://localhost:9000/api/Janus/Customer(1)?\$expand=Orders"
+```

--- a/docs-src/docs/janus/rest-join-strategy.md
+++ b/docs-src/docs/janus/rest-join-strategy.md
@@ -1,0 +1,122 @@
+---
+sidebar_position: 12
+---
+
+# JOIN Strategy: RTTI vs VIEW
+
+Janus REST/Horse supports two complementary strategies for returning joined data over HTTP.
+
+## Strategy A — RTTI via `$expand`
+
+Use the `$expand` query parameter with a relationship name defined via `[ForeignKey]` / `[Association]` attributes.
+
+```
+GET /api/Janus/Customer(1)?$expand=Orders
+```
+
+### When to use
+
+- Simple one-to-one or one-to-many associations.
+- Moderate data volumes (dozens to low hundreds of related rows).
+- When DDL access to the database is unavailable.
+
+### Limitation
+
+Each `$expand` generates additional queries via RTTI reflection (N+1 pattern). For large result sets or complex multi-join queries, prefer Strategy B.
+
+### Delphi model example
+
+```delphi
+[Entity]
+[Table('customer', '')]
+[PrimaryKey('id', 'Primary key')]
+TCustomer = class
+  [Column('id', ftInteger)]
+  property Id: Integer ...;
+end;
+
+[Entity]
+[Table('order', '')]
+[PrimaryKey('id', 'Primary key')]
+TOrder = class
+  [Column('customer_id', ftInteger)]
+  [ForeignKey('fk_order_customer', 'TCustomer', 'id', 'customer_id')]
+  property CustomerId: Integer ...;
+end;
+```
+
+---
+
+## Strategy B — VIEW via FluentSQL + DataEngine
+
+Define a database VIEW containing the desired JOIN query. Map a Delphi class to the view using `[View]` and/or `[Table]`. Use `TRESTViewManager.EnsureView` at startup to create/update the view.
+
+```
+GET /api/Janus/CustomerOrderSummary
+```
+
+### When to use
+
+- Complex multi-table JOINs.
+- Aggregations (COUNT, SUM, AVG).
+- High-traffic endpoints where per-request N+1 overhead is unacceptable.
+- When the DBA can own and optimize the view independently.
+
+### `TRESTViewManager.EnsureView` — startup call
+
+```delphi
+uses
+  FluentSQL,
+  Janus.Server.RestView.Manager;
+
+// In your application startup:
+var
+  LSelect: IFluentSQL;
+begin
+  LSelect := FluentSQL.Query(dbnFirebird)
+    .Select(['c.id AS customer_id', 'c.name AS customer_name',
+             'COUNT(o.id) AS order_count', 'SUM(o.total) AS total_amount'])
+    .From('customer c')
+    .LeftJoin('order o', 'o.customer_id = c.id')
+    .GroupBy(['c.id', 'c.name']);
+
+  TRESTViewManager.EnsureView(TCustomerOrderSummary, LSelect, FConnection);
+end;
+```
+
+> **Important:** `EnsureView` is an administrative setup operation. **Never call it inside a REST request handler.** Call it once during application initialization.
+
+### Delphi model example
+
+```delphi
+[Entity]
+[View('customer_order_summary', '')]
+[Table('customer_order_summary', '')]
+TCustomerOrderSummary = class
+  [Column('customer_id', ftInteger)]   property CustomerId: Integer ...;
+  [Column('customer_name', ftString, 100)] property CustomerName: String ...;
+  [Column('order_count', ftInteger)]   property OrderCount: Integer ...;
+  [Column('total_amount', ftFloat)]    property TotalAmount: Double ...;
+end;
+```
+
+The class automatically inherits read-only semantics because it has a `[View]` attribute — no `[RESTReadOnly]` needed.
+
+### Database compatibility
+
+| Database | Strategy used |
+|----------|--------------|
+| PostgreSQL, MySQL, Oracle | `CREATE OR REPLACE VIEW` |
+| SQLite, Firebird, MSSQL, others | `DROP VIEW IF EXISTS` + `CREATE VIEW` |
+
+---
+
+## Summary
+
+| | RTTI `$expand` | VIEW Strategy |
+|-|---------------|--------------|
+| Setup | Zero DDL | Requires `EnsureView` at startup |
+| SQL | N+1 queries | Single optimized VIEW query |
+| Complexity | Simple associations | Complex JOINs / aggregations |
+| Write protection | Not applicable | Automatic (implied by `[View]`) |
+| Recommended for | Low-volume joins | Production-grade reporting queries |

--- a/docs-src/docs/janus/rest-readonly.md
+++ b/docs-src/docs/janus/rest-readonly.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 11
+---
+
+# RESTReadOnly Attribute
+
+The `[RESTReadOnly]` attribute marks a mapped class as read-only at the REST layer. GET requests (SELECT) are always allowed; POST, PUT, and DELETE return a deterministic JSON error.
+
+## Declaration
+
+```delphi
+uses MetaDbDiff.Mapping.Attributes;
+
+[Entity]
+[Table('product', '')]
+[PrimaryKey('id', 'Primary key')]
+[RESTReadOnly]
+TProduct = class
+  // ...
+end;
+```
+
+## Behaviour
+
+| HTTP verb | Behaviour |
+|-----------|-----------|
+| `GET` | Passes through normally |
+| `POST` | Returns `{"exception":"Resource TProduct is read-only (RESTReadOnly)"}` |
+| `PUT` | Returns `{"exception":"Resource TProduct is read-only (RESTReadOnly)"}` |
+| `DELETE` | Returns `{"exception":"Resource TProduct is read-only (RESTReadOnly)"}` |
+
+The check runs **before** any database operation, so no row is ever touched on a blocked write.
+
+## Implicit read-only via `[View]`
+
+Classes decorated with `[View]` are implicitly read-only. You do not need to add `[RESTReadOnly]` to a view class — the server blocks writes automatically.
+
+## cURL example
+
+```bash
+# GET succeeds
+curl http://localhost:9000/api/Janus/Product
+
+# POST blocked
+curl -X POST http://localhost:9000/api/Janus/Product \
+     -H "Content-Type: application/json" \
+     -d '{"name":"New","price":9.99}'
+# → {"exception":"Resource TProduct is read-only (RESTReadOnly)"}
+```
+
+## Delphi registration example
+
+```delphi
+TRegisterClass.RegisterEntity(TProduct);
+
+LServer := TRESTServerHorse.Create(Self, FConnection);
+THorse.Listen(9000);
+```
+
+## Comparison with `[NotServerUse]`
+
+| Attribute | Effect |
+|-----------|--------|
+| `[NotServerUse]` | Blocks ALL REST access (GET + write) |
+| `[RESTReadOnly]` | Allows GET; blocks POST/PUT/DELETE |

--- a/docs-src/docs/janus/user/guides/restful.md
+++ b/docs-src/docs/janus/user/guides/restful.md
@@ -84,3 +84,11 @@ Banco de dados
 - Aplicações cliente-servidor via HTTP.
 - Quando o banco não pode ser acessado diretamente do cliente.
 - Multi-camada com autenticação centralizada no servidor.
+
+## Referências de funcionalidade avançada (ESP-002)
+
+| Tópico | Documento |
+|--------|-----------|
+| Consulta OData (operadores, funções, lógica) | [OData Query Reference](../../odata-reference.md) |
+| Atributo `[RESTReadOnly]` | [RESTReadOnly](../../rest-readonly.md) |
+| Estratégia de JOIN (RTTI vs VIEW) | [JOIN Strategy](../../rest-join-strategy.md) |


### PR DESCRIPTION
Batch release — tasks: #130

## Summary

- ESP-002 REST/Horse OData Hardening: word-boundary tokenizer, `[RESTReadOnly]` attribute, JOIN via RTTI (`$expand`) and VIEW (`TRESTViewManager`), 44 parser unit tests, 24 integration test stubs, updated Horse example, technical documentation.

## Technical Debt

Caveats registered in #131 (JanusRestHorse runtime tests, FluentSQL duplicate uses, sidebar entries, HorseJanus.dpr update, MetaDbDiff push decision).