### PR TITLE
release: merge develop into main — v2.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Added
+- Suite de testes de integração REST/Horse via Driver: extensão de `RestHorseTest.Base.pas` com campo `FPrefix` e método `BuildResourceURL`; criação de `TestJanusRESTHorseDriver.pas` com 8 cenários CRUD via prefixo `api/Janus`; atualização de `JanusRestHorse.dpr` ([#134](https://github.com/ModernDelphiWorks/Janus/issues/134))
+
+### Fixed
+- Fechamento dos três caveats pós-release de v2.20.0: remoção da cláusula `uses FluentSQL.Interfaces` duplicada em `Janus.Server.RestView.Manager.pas`; adição da categoria `RESTful` no sidebar do Docusaurus com links para `odata-reference`, `rest-readonly` e `rest-join-strategy`; adição de exemplo `[RESTReadOnly]` em `HorseJanus.dpr` com controller e model dedicados ([#133](https://github.com/ModernDelphiWorks/Janus/issues/133))
+- Alinhamento do contrato de prefixo nas fixtures de teste: adição de `FPrefix := 'api/Janus'` antes de `inherited Setup` em `TestJanusRESTReadOnly` e `TestJanusRESTJoinView`; substituição de `_BuildURL` hardcoded por delegação a `BuildResourceURL` da classe base ([#135](https://github.com/ModernDelphiWorks/Janus/issues/135))
+
 ## [v2.19.14](https://github.com/ModernDelphiWorks/Janus/releases/tag/v2.19.14) — 2026-04-12
 
 ### Changed

--- a/Examples/Delphi/RESTful/Horse/HorseJanus.dpr
+++ b/Examples/Delphi/RESTful/Horse/HorseJanus.dpr
@@ -15,6 +15,8 @@ uses
   HorseJanus.DAO.Base in 'dao\HorseJanus.DAO.Base.pas',
   HorseJanus.Controller.Master in 'controller\HorseJanus.Controller.Master.pas',
   HorseJanus.Controller.Client in 'controller\HorseJanus.Controller.Client.pas',
+  HorseJanus.Controller.ReadOnly in 'controller\HorseJanus.Controller.ReadOnly.pas',
+  Janus.Model.ReadOnly in 'models\Janus.Model.ReadOnly.pas',
   System.Classes;
 
 begin
@@ -32,6 +34,8 @@ begin
   THorse.Get('client/:id', HorseJanus.Controller.Client.Find);
   THorse.Put('client/:id', HorseJanus.Controller.Client.Update);
   THorse.Delete('client/:id', HorseJanus.Controller.Client.Delete);
+
+  THorse.Get('readonly', HorseJanus.Controller.ReadOnly.List);
 
   THorse.Listen(9000, '127.0.0.1',
     procedure

--- a/Examples/Delphi/RESTful/Horse/controller/HorseJanus.Controller.ReadOnly.pas
+++ b/Examples/Delphi/RESTful/Horse/controller/HorseJanus.Controller.ReadOnly.pas
@@ -1,0 +1,47 @@
+// Demonstrates the [RESTReadOnly] attribute guard.
+// POST, PUT, and DELETE are intentionally omitted — the framework blocks them
+// at the OData parsing layer when [RESTReadOnly] is present on the model class.
+unit HorseJanus.Controller.ReadOnly;
+
+interface
+
+uses
+  Horse,
+  HorseJanus.DAO.Base,
+  System.JSON,
+  REST.Json,
+  Janus.Json,
+  System.Generics.Collections,
+  Janus.Model.ReadOnly,
+  DM.Connection;
+
+procedure List(Req: THorseRequest; Res: THorseResponse; Next: TProc);
+
+implementation
+
+procedure List(Req: THorseRequest; Res: THorseResponse; Next: TProc);
+var
+  LItems: TObjectList<TReadOnlyModel>;
+  LConn: TDMConn;
+  LDao: THorseJanusDAOBase<TReadOnlyModel>;
+begin
+  LConn := TDMConn.Create(nil);
+  try
+    LDao := THorseJanusDAOBase<TReadOnlyModel>.Create(LConn.FDConnection1);
+    try
+      LItems := LDao.listAll;
+      try
+        Res.Send(TJanusJson.ObjectListToJsonString<TReadOnlyModel>(LItems))
+           .ContentType('application/json');
+      finally
+        LItems.Free;
+      end;
+    finally
+      LDao.Free;
+    end;
+  finally
+    LConn.Free;
+  end;
+end;
+
+end.

--- a/Examples/Delphi/RESTful/Horse/models/Janus.Model.ReadOnly.pas
+++ b/Examples/Delphi/RESTful/Horse/models/Janus.Model.ReadOnly.pas
@@ -1,0 +1,40 @@
+unit Janus.Model.ReadOnly;
+
+interface
+
+uses
+  Classes,
+  DB,
+  SysUtils,
+  Generics.Collections,
+  /// orm
+  MetaDbDiff.mapping.attributes,
+  MetaDbDiff.Types.Mapping,
+  MetaDbDiff.Mapping.Register;
+
+type
+  // [RESTReadOnly] blocks POST, PUT, and DELETE at the framework level.
+  // Only GET operations are permitted for entities decorated with this attribute.
+  [Entity]
+  [Table('readonly_example', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTReadOnly]
+  TReadOnlyModel = class
+  private
+    Fid: Integer;
+    Fname: String;
+  public
+    [Restrictions([TRestriction.NoUpdate, TRestriction.NotNull])]
+    [Column('id', ftInteger)]
+    property id: Integer read Fid write Fid;
+
+    [Column('name', ftString, 100)]
+    property name: String read Fname write Fname;
+  end;
+
+implementation
+
+initialization
+  TRegisterClass.RegisterEntity(TReadOnlyModel);
+
+end.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,9 +10,9 @@ Consolidar o Janus como ORM Delphi multi-contexto com evolucao previsivel do nuc
 
 ## Estado estrategico atual
 
-- Versao mais recente: v2.19.3.
-- Fase atual: execucao de R18.x — trilha de confiabilidade e governanca pre-gate para publicacao deterministica.
-- Leitura do ciclo: R17.x encerrado e consolidado; R18.1 a R18.10 formalizados/validados em rodadas sucessivas; R18.11 em execucao ativa (issue #122) para reconciliar o blocker de develop causado por diff tracked pre-existente em `ROADMAP.md`.
+- Versao mais recente: v2.20.0 (released 2026-04-20).
+- Fase atual: pos-release v2.20.0 — tres commits (#133, #134, #135) em develop pendentes de release v2.20.1.
+- Leitura do ciclo: R19 entregue como v2.20.0 (#130); R19.1 fechado (#133); R19.2 fechado (#134, #135); artefatos de governanca sendo consolidados para gate do /release v2.20.1.
 
 ## Marcos recentes
 
@@ -53,19 +53,36 @@ Consolidar o Janus como ORM Delphi multi-contexto com evolucao previsivel do nuc
 13. Formalizar a proxima demanda R18.10 como ESP-002 (feature): estabelecer baseline deterministico de validacao pre-gate para freshness de evidencias e isolamento de escopo (diff in-scope vs out-of-scope) antes de `/review`, `/test` e `/develop`.
 14. Formalizar a demanda de correcao R18.11 como ESP-003 (bug): reconciliar explicitamente o diff tracked pre-existente de `ROADMAP.md` para eliminar bloqueio recorrente em `/develop` (`NO_COMMITTABLE_FILES`) com evidencia objetiva de escopo.
 
-### R19 — REST/Horse OData hardening, RESTReadOnly e JOIN via View (em formalizacao)
+### R19.1 — Post-release caveat closure for v2.20.0 — delivered 2026-04-20
+
+- [x] Fix: `FluentSQL.Interfaces` duplicate removed from `implementation uses` in `RestView.Manager.pas` — delivered #133 2026-04-20
+- [x] Fix: Docusaurus sidebar updated with `RESTful` category linking `odata-reference`, `rest-readonly`, `rest-join-strategy` — delivered #133 2026-04-20
+- [x] Fix: `HorseJanus.dpr` extended with `[RESTReadOnly]` model + controller example — delivered #133 2026-04-20
+
+### R19.2 — REST/Horse via Driver: suite de testes de integração (entregue)
+
+- Objetivo estrategico: fechar lacuna de cobertura de testes — `TRESTServerHorse` com prefixo de URL (`'api/Janus'`) não tinha suite de testes dedicada.
+- Estado atual: entregue — commits b70aecf (#134) e 61a02c7 (#135) em develop 2026-04-20.
+- Demanda ativa: nenhuma — rodada encerrada.
+- Itens da rodada:
+  - [x] Estender `RestHorseTest.Base.pas` com campo `FPrefix` e método `BuildResourceURL` — delivered #134 2026-04-20
+  - [x] Criar `TestJanusRESTHorseDriver.pas` — fixture com prefixo `api/Janus` e mínimo 8 testes CRUD — delivered #134 2026-04-20
+  - [x] Atualizar `JanusRestHorse.dpr` com a nova unit de testes — delivered #134 2026-04-20
+- Proxima decisao: apos QA, avaliar expansao de cobertura (outros frameworks via Driver: DMVC, MARS, WiRL).
+
+### R19 — REST/Horse OData hardening, RESTReadOnly e JOIN via View (entregue como v2.20.0)
 
 - Objetivo estrategico: consolidar a camada REST/Horse como base OData testada, com granularidade read-only por classe e alternativa explicita de JOIN via VIEW gerada por FluentSQL + DataEngine.
-- Estado atual: ciclo formalizado por /architect em 2026-04-20; 6 slices definidos; 4 ADRs aprovados; handoff pronto para /task.
-- Demanda ativa: ESP-002 (feature) — cobertura de testes REST/Horse, tokenizacao do parser OData, atributo `[RESTReadOnly]`, `TRESTViewManager` e atualizacao do exemplo `HorseJanus`.
+- Estado atual: entregue como v2.20.0 (#130) e complementos em develop (#133).
+- Demanda ativa: nenhuma — rodada encerrada.
 - Itens da rodada:
-  - [ ] Suite de testes unitarios do parser OData (`TestJanusRESTQueryParse.pas` ≥ 30 cenarios).
-  - [ ] Suite de integracao CRUD Horse + SQLite (`TestJanusRESTHorseIntegration.pas` ≥ 12 cenarios).
-  - [ ] Atributo `[RESTReadOnly]` com cache em `MetaDbDiff` e guard em `TAppResourceBase`.
-  - [ ] Parser OData tokenizado com operadores logicos (and/or/not) e funcoes (contains/startswith/endswith/tolower/toupper).
-  - [ ] Validacao de `$expand` RTTI via teste master/detail.
-  - [ ] Utilitario `TRESTViewManager` para geracao/atualizacao de VIEW via FluentSQL DDL + DataEngine.
-  - [ ] Atualizacao do exemplo `Examples/Delphi/RESTful/Horse/` e documentacao em `docs-src/docs/janus/`.
+  - [x] Suite de testes unitarios do parser OData (`TestJanusRESTQueryParse.pas` ≥ 30 cenarios) — delivered #130 2026-04-20
+  - [x] Suite de integracao CRUD Horse + SQLite (`TestJanusRESTHorseIntegration.pas` ≥ 12 cenarios) — delivered #130 2026-04-20
+  - [x] Atributo `[RESTReadOnly]` com cache em `MetaDbDiff` e guard em `TAppResourceBase` — delivered #130 2026-04-20
+  - [x] Parser OData tokenizado com operadores logicos (and/or/not) e funcoes (contains/startswith/endswith/tolower/toupper) — delivered #130 2026-04-20
+  - [x] Validacao de `$expand` RTTI via teste master/detail — delivered #130 2026-04-20
+  - [x] Utilitario `TRESTViewManager` para geracao/atualizacao de VIEW via FluentSQL DDL + DataEngine — delivered #130 2026-04-20
+  - [x] Atualizacao do exemplo `Examples/Delphi/RESTful/Horse/` e documentacao em `docs-src/docs/janus/` — delivered #130 2026-04-20, complemento #133 2026-04-20
 - Proxima decisao: apos QA, avaliar expansao para outros web frameworks (DMVC/MARS/WiRL/DataSnap) e Cliente REST.
 
 ## Backlog resumido
@@ -100,5 +117,5 @@ Consolidar o Janus como ORM Delphi multi-contexto com evolucao previsivel do nuc
 3. Registre entregas concluidas no changelog, analises em discussoes e execucao da rodada nos artefatos da pipeline.
 4. Se a informacao nao altera prioridade, fase ou direcao do projeto, ela nao deve aumentar o roadmap.
 
-*Ultima atualizacao: 2026-04-20*
+*Ultima atualizacao: 2026-04-20 — ESP-004 pre-release v2.20.1 artifact consolidation: R19, R19.1, R19.2 marked delivered; CHANGELOG [Unreleased] populated*
 

--- a/Source/Core/Janus.Command.Abstract.pas
+++ b/Source/Core/Janus.Command.Abstract.pas
@@ -31,6 +31,7 @@ interface
 uses
   DB,
   Rtti,
+  SysUtils,
   DataEngine.FactoryInterfaces,
   Janus.Driver.Register,
   Janus.DML.Interfaces;
@@ -61,6 +62,16 @@ begin
   FConnection := AConnection;
   // Driver do banco de dados
   FGeneratorCommand := TDriverRegister.GetDriver(ADriverName);
+  // Surface a precise error instead of letting a nil factory AV downstream.
+  // The historical failure was "offset 0x121421 Read of address 00000008"
+  // deep in TDictionary — opaque and nearly undiagnosable. If GetDriver
+  // ever hands back nil (e.g., a factory that returned nil without
+  // raising), we now fail here with an actionable message.
+  if not Assigned(FGeneratorCommand) then
+    raise Exception.Create(
+      'Janus: o gerador DML para o driver solicitado retornou nil. ' +
+      'Verifique se a unit "Janus.DML.Generator.<driver>.pas" est� na ' +
+      'cl�usula uses do seu projeto.');
   FGeneratorCommand.SetConnection(AConnection);
   // Lista de parametros
   FParams := TParams.Create;

--- a/Source/RESTful/Server/Janus.Server.Resource.pas
+++ b/Source/RESTful/Server/Janus.Server.Resource.pas
@@ -45,6 +45,7 @@ type
     const cRESOURCENOTREGISTER = '{"exception":"Resource [%s] not registered on the server!"}';
     const cRESOURCEPERMITION = '{"exception":"Resource [%s] without access permission by the [NotServerUse] attribute!"}';
     const cRESOURCEREADONLY = '{"exception":"Resource %s is read-only (RESTReadOnly)"}';
+    const cRESOURCEVERBNOTALLOWED = '{"exception":"HTTP %s not allowed for %s"}';
     const cEXCEPTIONJSON = '{"exception":"There was an error in trying to convert JSON into the class [%s]!"}';
     const cRESOURCEDELETE = '{"result":"Resource %s delete command executed successfully"}';
     const cRESOURCEINSERT = '{"result":"Resource %s insert command executed successfully", "params":[{%s}]}';
@@ -78,6 +79,7 @@ implementation
 
 uses
   MetaDbDiff.mapping.classes,
+  MetaDbDiff.mapping.attributes,
   MetaDbDiff.rtti.helper,
   Janus.Objects.Helper,
   Janus.Core.Consts;
@@ -138,6 +140,7 @@ var
   LObject: TObject;
   LClassType: TClass;
   LObjectSet: TRESTObjectSet;
+  LAllowVerbs: TRESTAllowVerbCache;
 
   procedure ExceptionExecute;
   begin
@@ -170,6 +173,11 @@ begin
   if TMappingExplorer.GetRESTReadOnly(LClassType) then
     raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
 
+  LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
+  if LAllowVerbs.HasAllowList then
+    if not (rvDELETE in LAllowVerbs.AllowedVerbs) then
+      raise Exception.CreateFmt(cRESOURCEVERBNOTALLOWED, ['DELETE', AQuery.ResourceName]);
+
   try
     LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
     try
@@ -201,6 +209,7 @@ var
   LClassType: TClass;
   LObjectSet: TRESTObjectSet;
   LNotSeverUse: Boolean;
+  LAllowVerbs: TRESTAllowVerbCache;
 begin
   LClassType := TMappingExplorer.GetRepositoryMapping
                                 .FindEntityByName(AQuery.ResourceName);
@@ -211,6 +220,12 @@ begin
   LNotSeverUse := TMappingExplorer.GetNotServerUse(LClassType);
   if LNotSeverUse then
     raise Exception.CreateFmt(cRESOURCEPERMITION, [AQuery.ResourceName]);
+
+  LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
+  if LAllowVerbs.HasAllowList then
+    if not TMappingExplorer.GetRESTReadOnly(LClassType) then
+      if not (rvGET in LAllowVerbs.AllowedVerbs) then
+        raise Exception.CreateFmt(cRESOURCEVERBNOTALLOWED, ['GET', AQuery.ResourceName]);
 
   LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
   try
@@ -238,6 +253,7 @@ var
   LClassType: TClass;
   LObjectSet: TRESTObjectSet;
   LValues: String;
+  LAllowVerbs: TRESTAllowVerbCache;
 begin
   LClassType := TMappingExplorer.GetRepositoryMapping
                                 .FindEntityByName(AQuery.ResourceName);
@@ -246,6 +262,11 @@ begin
 
   if TMappingExplorer.GetRESTReadOnly(LClassType) then
     raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
+  LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
+  if LAllowVerbs.HasAllowList then
+    if not (rvPOST in LAllowVerbs.AllowedVerbs) then
+      raise Exception.CreateFmt(cRESOURCEVERBNOTALLOWED, ['POST', AQuery.ResourceName]);
 
   try
     LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
@@ -293,6 +314,7 @@ var
   LPrimaryKey: TPrimaryKeyColumnsMapping;
   LColumn: TColumnMapping;
   LWhere: String;
+  LAllowVerbs: TRESTAllowVerbCache;
 begin
   LClassType := TMappingExplorer.GetRepositoryMapping
                                 .FindEntityByName(AQuery.ResourceName);
@@ -301,6 +323,11 @@ begin
 
   if TMappingExplorer.GetRESTReadOnly(LClassType) then
     raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
+  LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
+  if LAllowVerbs.HasAllowList then
+    if not (rvPUT in LAllowVerbs.AllowedVerbs) then
+      raise Exception.CreateFmt(cRESOURCEVERBNOTALLOWED, ['PUT', AQuery.ResourceName]);
   try
     LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
     LObjectNew := LClassType.Create;

--- a/Source/RESTful/Server/Janus.Server.RestObject.Manager.pas
+++ b/Source/RESTful/Server/Janus.Server.RestObject.Manager.pas
@@ -129,7 +129,13 @@ end;
 
 destructor TRESTObjectManager.Destroy;
 begin
-  FLazyToken.Invalidate;
+  // Guarded against auto-Destroy after a constructor failure: if Create
+  // raises before each field is initialized, Delphi still invokes Destroy
+  // on the partially-constructed instance. Without these checks, the first
+  // nil field dereference masks the original constructor exception with a
+  // secondary AV, which is what surfaced as the recurring REST test AV.
+  if Assigned(FLazyToken) then
+    FLazyToken.Invalidate;
   FProcessingObjects.Free;
   FDMLCommandFactory.Free;
   FObjectInternal.Free;

--- a/Source/RESTful/Server/Janus.Server.RestView.Manager.pas
+++ b/Source/RESTful/Server/Janus.Server.RestView.Manager.pas
@@ -47,7 +47,6 @@ type
 implementation
 
 uses
-  FluentSQL.Interfaces,
   MetaDbDiff.Mapping.Classes;
 
 { TRESTViewManager }

--- a/Test/Delphi/JanusRestHorse.dpr
+++ b/Test/Delphi/JanusRestHorse.dpr
@@ -23,7 +23,9 @@ uses
   /// Integration Test Suites — ESP-002
   TestJanusRESTHorseIntegration in 'Tests\TestJanusRESTHorseIntegration.pas',
   TestJanusRESTReadOnly         in 'Tests\TestJanusRESTReadOnly.pas',
-  TestJanusRESTJoinView         in 'Tests\TestJanusRESTJoinView.pas';
+  TestJanusRESTJoinView         in 'Tests\TestJanusRESTJoinView.pas',
+  /// Integration Test Suites — ESP-006
+  TestJanusRESTHorseDriver      in 'Tests\TestJanusRESTHorseDriver.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/JanusRestHorse.dpr
+++ b/Test/Delphi/JanusRestHorse.dpr
@@ -9,12 +9,23 @@ uses
   System.Classes,
   System.SysUtils,
   System.IOUtils,
+  // FireDAC silent wait-cursor — required when TFDConnection is used from
+  // non-VCL threads (Indy worker threads inside Horse). Registers a null
+  // GUI provider so FireDAC does not invoke VCL cursor callbacks that AV
+  // outside the main thread.
+  FireDAC.ConsoleUI.Wait,
+  FireDAC.Comp.Client,
   {$IFDEF TESTINSIGHT}
   TestInsight.DUnitX,
   {$ENDIF}
   DUnitX.TestFramework,
   DUnitX.Loggers.Console,
   DUnitX.Loggers.Xml.NUnit,
+  /// DML generator registration — this unit's initialization block registers
+  /// the SQLite factory with TDriverRegister. Without it, TCommandSelecter's
+  /// construction path hits an unregistered driver and AVs deep in the
+  /// TDictionary miss path.
+  Janus.DML.Generator.SQLite,
   /// Models
   MetaDbDiff.Mapping.Register,
   /// Test Infrastructure
@@ -49,6 +60,12 @@ begin
   Exit;
 {$ENDIF}
   System.ExitCode := EXIT_FAILURE;
+  // Required for any Delphi process that allocates from multiple threads.
+  // Horse dispatches requests on Indy worker threads; without this the RTL
+  // memory manager skips cross-thread locking and allocations race into AVs.
+  IsMultiThread := True;
+  // FireDAC manager-level silent: prevents any thread-unsafe GUI dispatch.
+  FDManager.SilentMode := True;
   try
     LRunStartTime := Now;
     TDUnitX.CheckCommandLine;

--- a/Test/Delphi/JanusRestHorse.dpr
+++ b/Test/Delphi/JanusRestHorse.dpr
@@ -25,7 +25,9 @@ uses
   TestJanusRESTReadOnly         in 'Tests\TestJanusRESTReadOnly.pas',
   TestJanusRESTJoinView         in 'Tests\TestJanusRESTJoinView.pas',
   /// Integration Test Suites — ESP-006
-  TestJanusRESTHorseDriver      in 'Tests\TestJanusRESTHorseDriver.pas';
+  TestJanusRESTHorseDriver      in 'Tests\TestJanusRESTHorseDriver.pas',
+  /// Integration Test Suites — R20 method-level grant (#137)
+  TestJanusRESTMethodGrant      in 'Tests\TestJanusRESTMethodGrant.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/Tests/RestHorseTest.Base.pas
+++ b/Test/Delphi/Tests/RestHorseTest.Base.pas
@@ -35,6 +35,8 @@ type
   private
     FDConnection: TFDConnection;
     FConnection: IDBConnection;
+    FHorseDConnection: TFDConnection;
+    FHorseConnection: IDBConnection;
     FServer: TRESTServerHorse;
     FPort: Integer;
     FServerThread: TThread;
@@ -54,6 +56,10 @@ type
     // Inserts seed data for tests
     procedure SeedCustomers;
   public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
     [Setup]
     procedure Setup;
     [TearDown]
@@ -64,6 +70,7 @@ implementation
 
 uses
   DataEngine.FactoryFireDAC,
+  Horse.Core.RouterTree,
   RestHorseTest.Models;
 
 { TRestHorseTestBase }
@@ -172,7 +179,7 @@ end;
 procedure TRestHorseTestBase._StartHorse;
 begin
   FPort := 9890 + Random(100);
-  FServer := TRESTServerHorse.Create(nil, FConnection, FPrefix);
+  FServer := TRESTServerHorse.Create(nil, FHorseConnection, FPrefix);
   FServerThread := TThread.CreateAnonymousThread(
     procedure
     begin
@@ -195,7 +202,7 @@ begin
   FreeAndNil(FServer);
 end;
 
-procedure TRestHorseTestBase.Setup;
+procedure TRestHorseTestBase.SetupFixture;
 begin
   Randomize;
   FDConnection := TFDConnection.Create(nil);
@@ -203,21 +210,45 @@ begin
   FDConnection.Params.Database := cTEST_DB_PATH;
   FDConnection.Params.Values['OpenMode'] := 'CreateUTF8';
   FDConnection.Connected := True;
-
   FConnection := TFactoryFireDAC.Create(FDConnection, dnSQLite);
+  FHorseDConnection := TFDConnection.Create(nil);
+  FHorseDConnection.Params.DriverID := 'SQLite';
+  FHorseDConnection.Params.Database := cTEST_DB_PATH;
+  FHorseDConnection.Params.Values['OpenMode'] := 'CreateUTF8';
+  FHorseDConnection.ResourceOptions.SilentMode := True;
+  FHorseDConnection.Connected := True;
+  FHorseConnection := TFactoryFireDAC.Create(FHorseDConnection, dnSQLite);
   _RegisterTestEntities;
-  _CreateSchema;
   _StartHorse;
 end;
 
-procedure TRestHorseTestBase.TearDown;
+procedure TRestHorseTestBase.TearDownFixture;
+var
+  LOldRoutes: THorseRouterTree;
+  LNewRoutes: THorseRouterTree;
 begin
   _StopHorse;
+  LOldRoutes := THorse.Routes;
+  LNewRoutes := THorseRouterTree.Create;
+  THorse.Routes := LNewRoutes;
+  LOldRoutes.Free;
+  FHorseConnection := nil;
+  FHorseDConnection.Connected := False;
+  FreeAndNil(FHorseDConnection);
   FConnection := nil;
   FDConnection.Connected := False;
   FreeAndNil(FDConnection);
   if TFile.Exists(cTEST_DB_PATH) then
     TFile.Delete(cTEST_DB_PATH);
+end;
+
+procedure TRestHorseTestBase.Setup;
+begin
+  _CreateSchema;
+end;
+
+procedure TRestHorseTestBase.TearDown;
+begin
 end;
 
 end.

--- a/Test/Delphi/Tests/RestHorseTest.Base.pas
+++ b/Test/Delphi/Tests/RestHorseTest.Base.pas
@@ -42,8 +42,10 @@ type
     procedure _CreateSchema;
     procedure _RegisterTestEntities;
   protected
+    FPrefix: String;
     property Connection: IDBConnection read FConnection;
     property Port: Integer read FPort;
+    function BuildResourceURL(const AResource: String): String;
     // Executes all pending DDL/DML against the test database
     procedure ExecuteSQL(const ASQL: String);
     // Resets the test database to a known clean state
@@ -126,10 +128,18 @@ begin
   FConnection.ExecuteDirect(ASQL);
 end;
 
+function TRestHorseTestBase.BuildResourceURL(const AResource: String): String;
+begin
+  if FPrefix <> '' then
+    Result := Format('http://127.0.0.1:%d/%s/%s', [FPort, FPrefix, AResource])
+  else
+    Result := Format('http://127.0.0.1:%d/%s', [FPort, AResource]);
+end;
+
 procedure TRestHorseTestBase._StartHorse;
 begin
   FPort := 9890 + Random(100);
-  FServer := TRESTServerHorse.Create(nil, FConnection);
+  FServer := TRESTServerHorse.Create(nil, FConnection, FPrefix);
   FServerThread := TThread.CreateAnonymousThread(
     procedure
     begin

--- a/Test/Delphi/Tests/RestHorseTest.Base.pas
+++ b/Test/Delphi/Tests/RestHorseTest.Base.pas
@@ -5,6 +5,7 @@ interface
 uses
   SysUtils,
   Classes,
+  IOUtils,
   SyncObjs,
   DUnitX.TestFramework,
   // DataEngine
@@ -73,6 +74,10 @@ begin
   TRegisterClass.RegisterEntity(TOrderTest);
   TRegisterClass.RegisterEntity(TProductTest);
   TRegisterClass.RegisterEntity(TCustomerOrderSummary);
+  TRegisterClass.RegisterEntity(TGrantGETOnly);
+  TRegisterClass.RegisterEntity(TGrantGETAndPOST);
+  TRegisterClass.RegisterEntity(TGrantFullAllow);
+  TRegisterClass.RegisterEntity(TGrantReadOnlyWithPOST);
 end;
 
 procedure TRestHorseTestBase._CreateSchema;
@@ -97,13 +102,41 @@ const
     '  name  VARCHAR(100) NOT NULL,' +
     '  price REAL DEFAULT 0' +
     ')';
+  LDDL_GRANT_GET_ONLY =
+    'CREATE TABLE IF NOT EXISTS grant_get_only_test (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL' +
+    ')';
+  LDDL_GRANT_GET_POST =
+    'CREATE TABLE IF NOT EXISTS grant_get_post_test (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL' +
+    ')';
+  LDDL_GRANT_FULL_ALLOW =
+    'CREATE TABLE IF NOT EXISTS grant_full_allow_test (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL' +
+    ')';
+  LDDL_GRANT_READONLY_POST =
+    'CREATE TABLE IF NOT EXISTS grant_readonly_post_test (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL' +
+    ')';
 begin
   FConnection.ExecuteDirect('DROP TABLE IF EXISTS order_test');
   FConnection.ExecuteDirect('DROP TABLE IF EXISTS customer_test');
   FConnection.ExecuteDirect('DROP TABLE IF EXISTS product_test');
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS grant_get_only_test');
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS grant_get_post_test');
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS grant_full_allow_test');
+  FConnection.ExecuteDirect('DROP TABLE IF EXISTS grant_readonly_post_test');
   FConnection.ExecuteDirect(LDDL_CUSTOMER);
   FConnection.ExecuteDirect(LDDL_ORDER);
   FConnection.ExecuteDirect(LDDL_PRODUCT);
+  FConnection.ExecuteDirect(LDDL_GRANT_GET_ONLY);
+  FConnection.ExecuteDirect(LDDL_GRANT_GET_POST);
+  FConnection.ExecuteDirect(LDDL_GRANT_FULL_ALLOW);
+  FConnection.ExecuteDirect(LDDL_GRANT_READONLY_POST);
 end;
 
 procedure TRestHorseTestBase.ResetDatabase;

--- a/Test/Delphi/Tests/RestHorseTest.Models.pas
+++ b/Test/Delphi/Tests/RestHorseTest.Models.pas
@@ -4,6 +4,7 @@ interface
 
 uses
   DB,
+  MetaDbDiff.Types.Mapping,
   MetaDbDiff.Mapping.Attributes;
 
 type
@@ -78,6 +79,83 @@ type
 
     [Column('price', ftFloat)]
     property Price: Double read FPrice write FPrice;
+  end;
+
+  // Grant-list: GET only
+  [Entity]
+  [Table('grant_get_only_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTAllowGET]
+  TGrantGETOnly = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+  end;
+
+  // Grant-list: GET + POST
+  [Entity]
+  [Table('grant_get_post_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTAllowGET]
+  [RESTAllowPOST]
+  TGrantGETAndPOST = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+  end;
+
+  // Grant-list: all four verbs allowed
+  [Entity]
+  [Table('grant_full_allow_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTAllowGET]
+  [RESTAllowPOST]
+  [RESTAllowPUT]
+  [RESTAllowDELETE]
+  TGrantFullAllow = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+  end;
+
+  // RESTReadOnly + RESTAllowPOST: RESTReadOnly must win
+  [Entity]
+  [Table('grant_readonly_post_test', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTReadOnly]
+  [RESTAllowPOST]
+  TGrantReadOnlyWithPOST = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
   end;
 
   // View entity — read-only by nature (ADR-002 + ADR-003)

--- a/Test/Delphi/Tests/TestJanusRESTHorseDriver.pas
+++ b/Test/Delphi/Tests/TestJanusRESTHorseDriver.pas
@@ -1,0 +1,212 @@
+unit TestJanusRESTHorseDriver;
+
+interface
+
+uses
+  SysUtils,
+  Net.HTTPClient,
+  Net.URLClient,
+  DUnitX.TestFramework,
+  RestHorseTest.Base;
+
+type
+  [TestFixture]
+  TTestRESTHorseDriver = class(TRestHorseTestBase)
+  private
+    FHTTPClient: THTTPClient;
+    function _BuildURL(const AResource: String; const AQuery: String = ''): String;
+    function _Get(const AURL: String): String;
+    function _Post(const AURL: String; const ABody: String): String;
+    function _Put(const AURL: String; const ABody: String): String;
+    function _Delete(const AURL: String): String;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure GetList_WithPrefix_ReturnsJSONArray;
+    [Test]
+    procedure GetByID_WithPrefix_ReturnsJSON;
+    [Test]
+    procedure Post_WithPrefix_InsertsRecord;
+    [Test]
+    procedure Put_WithPrefix_UpdatesRecord;
+    [Test]
+    procedure Delete_WithPrefix_ByID;
+    [Test]
+    procedure Get_UnknownResource_WithPrefix_ReturnsError;
+    [Test]
+    procedure GetWithFilter_WithPrefix_ReturnsFiltered;
+    [Test]
+    procedure GetWithPagination_WithPrefix_ReturnsPaged;
+  end;
+
+implementation
+
+const
+  cTIMEOUT_MS = 2000;
+
+{ TTestRESTHorseDriver }
+
+procedure TTestRESTHorseDriver.Setup;
+begin
+  FPrefix := 'api/Janus';
+  inherited Setup;
+  FHTTPClient := THTTPClient.Create;
+  FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
+  FHTTPClient.ResponseTimeout := cTIMEOUT_MS;
+  SeedCustomers;
+end;
+
+procedure TTestRESTHorseDriver.TearDown;
+begin
+  FreeAndNil(FHTTPClient);
+  inherited TearDown;
+end;
+
+function TTestRESTHorseDriver._BuildURL(const AResource: String;
+  const AQuery: String): String;
+begin
+  Result := BuildResourceURL(AResource);
+  if AQuery <> '' then
+    Result := Result + '?' + AQuery;
+end;
+
+function TTestRESTHorseDriver._Get(const AURL: String): String;
+var
+  LResponse: IHTTPResponse;
+begin
+  LResponse := FHTTPClient.Get(AURL);
+  Result := LResponse.ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestRESTHorseDriver._Post(const AURL: String;
+  const ABody: String): String;
+var
+  LStream: TStringStream;
+  LResponse: IHTTPResponse;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    LResponse := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')]);
+    Result := LResponse.ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTHorseDriver._Put(const AURL: String;
+  const ABody: String): String;
+var
+  LStream: TStringStream;
+  LResponse: IHTTPResponse;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    LResponse := FHTTPClient.Put(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')]);
+    Result := LResponse.ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTHorseDriver._Delete(const AURL: String): String;
+var
+  LResponse: IHTTPResponse;
+begin
+  LResponse := FHTTPClient.Delete(AURL);
+  Result := LResponse.ContentAsString(TEncoding.UTF8);
+end;
+
+// 1. GET list with prefix → 200, JSON array
+procedure TTestRESTHorseDriver.GetList_WithPrefix_ReturnsJSONArray;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest'));
+  Assert.IsNotEmpty(LResult);
+  Assert.StartsWith('[', LResult.Trim);
+end;
+
+// 2. GET by ID with prefix → 200, JSON object
+procedure TTestRESTHorseDriver.GetByID_WithPrefix_ReturnsJSON;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest(1)'));
+  Assert.IsNotEmpty(LResult);
+  Assert.IsFalse(LResult.Contains('"exception"'));
+end;
+
+// 3. POST with prefix → inserts record
+procedure TTestRESTHorseDriver.Post_WithPrefix_InsertsRecord;
+var
+  LResult: String;
+begin
+  ResetDatabase;
+  LResult := _Post(_BuildURL('CustomerTest'),
+    '{"name":"Dave","email":"dave@test.com","active":true}');
+  Assert.IsFalse(LResult.Contains('"exception"'), 'POST returned exception: ' + LResult);
+  Assert.Contains(LResult, 'CustomerTest');
+end;
+
+// 4. PUT with prefix → updates record
+procedure TTestRESTHorseDriver.Put_WithPrefix_UpdatesRecord;
+var
+  LResult: String;
+begin
+  _Post(_BuildURL('CustomerTest'),
+    '{"name":"UpdateMe","email":"u@test.com","active":true}');
+  LResult := _Put(_BuildURL('CustomerTest'),
+    '{"id":1,"name":"Updated","email":"upd@test.com","active":true}');
+  Assert.IsFalse(LResult.Contains('"exception"'), 'PUT returned exception: ' + LResult);
+end;
+
+// 5. DELETE by ID with prefix
+procedure TTestRESTHorseDriver.Delete_WithPrefix_ByID;
+var
+  LResult: String;
+begin
+  _Post(_BuildURL('CustomerTest'),
+    '{"name":"ToDelete","email":"del@test.com","active":true}');
+  LResult := _Delete(_BuildURL('CustomerTest(1)'));
+  Assert.IsFalse(LResult.Contains('"exception"'), 'DELETE returned exception: ' + LResult);
+end;
+
+// 6. GET unknown resource with prefix → structured error
+procedure TTestRESTHorseDriver.Get_UnknownResource_WithPrefix_ReturnsError;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('NonExistentResource9999'));
+  Assert.Contains(LResult, 'exception');
+end;
+
+// 7. GET with $filter using prefix → filtered result
+procedure TTestRESTHorseDriver.GetWithFilter_WithPrefix_ReturnsFiltered;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest', '$filter=active eq 1'));
+  Assert.IsFalse(LResult.Contains('"exception"'), 'Filter returned exception: ' + LResult);
+  Assert.IsNotEmpty(LResult);
+end;
+
+// 8. GET with $top and $skip using prefix → paged result
+procedure TTestRESTHorseDriver.GetWithPagination_WithPrefix_ReturnsPaged;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest', '$top=2&$skip=1'));
+  Assert.IsNotEmpty(LResult);
+  Assert.IsFalse(LResult.Contains('"exception"'), 'Pagination returned exception: ' + LResult);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestRESTHorseDriver);
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTHorseDriver.pas
+++ b/Test/Delphi/Tests/TestJanusRESTHorseDriver.pas
@@ -21,6 +21,8 @@ type
     function _Put(const AURL: String; const ABody: String): String;
     function _Delete(const AURL: String): String;
   public
+    [SetupFixture]
+    procedure SetupFixture;
     [Setup]
     procedure Setup;
     [TearDown]
@@ -51,9 +53,14 @@ const
 
 { TTestRESTHorseDriver }
 
-procedure TTestRESTHorseDriver.Setup;
+procedure TTestRESTHorseDriver.SetupFixture;
 begin
   FPrefix := 'api/Janus';
+  inherited SetupFixture;
+end;
+
+procedure TTestRESTHorseDriver.Setup;
+begin
   inherited Setup;
   FHTTPClient := THTTPClient.Create;
   FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;

--- a/Test/Delphi/Tests/TestJanusRESTHorseDriver.pas
+++ b/Test/Delphi/Tests/TestJanusRESTHorseDriver.pas
@@ -4,6 +4,7 @@ interface
 
 uses
   SysUtils,
+  Classes,
   Net.HTTPClient,
   Net.URLClient,
   DUnitX.TestFramework,

--- a/Test/Delphi/Tests/TestJanusRESTJoinView.pas
+++ b/Test/Delphi/Tests/TestJanusRESTJoinView.pas
@@ -10,6 +10,7 @@ uses
   DUnitX.TestFramework,
   // FluentSQL
   FluentSQL,
+  FluentSQL.Interfaces,
   // Janus
   Janus.Server.RestView.Manager,
   RestHorseTest.Base,
@@ -121,13 +122,15 @@ var
   LSelect: IFluentSQL;
 begin
   LSelect := FluentSQL.Query(dbnSQLite)
-    .Select(['c.id AS customer_id',
-             'c.name AS customer_name',
-             'COUNT(o.id) AS order_count',
-             'COALESCE(SUM(o.total), 0) AS total_amount'])
+    .Select('c.id AS customer_id')
+    .Select('c.name AS customer_name')
+    .Select('COUNT(o.id) AS order_count')
+    .Select('COALESCE(SUM(o.total), 0) AS total_amount')
     .From('customer_test c')
-    .LeftJoin('order_test o', 'o.customer_id = c.id')
-    .GroupBy(['c.id', 'c.name']);
+    .LeftJoin('order_test o')
+    .OnCond('o.customer_id = c.id')
+    .GroupBy('c.id')
+    .GroupBy('c.name');
 
   TRESTViewManager.EnsureView(TCustomerOrderSummary, LSelect, Connection);
 end;
@@ -156,26 +159,26 @@ end;
 // CA-006 Test 1: EnsureView creates the VIEW without exception
 procedure TTestRESTJoinView.EnsureView_CreatesView_NoException;
 begin
-  Assert.WillNotRaise(
-    procedure
-    begin
-      _CreateSummaryView;
-    end,
-    Exception,
-    'EnsureView should not raise');
+  try
+    _CreateSummaryView;
+    Assert.IsTrue(True);
+  except
+    on E: Exception do
+      Assert.Fail('EnsureView raised: ' + E.Message);
+  end;
 end;
 
 // CA-006 Test 2: calling EnsureView again (idempotent) does not raise
 procedure TTestRESTJoinView.EnsureView_Idempotent_SecondCallNoException;
 begin
   _CreateSummaryView;
-  Assert.WillNotRaise(
-    procedure
-    begin
-      _CreateSummaryView;
-    end,
-    Exception,
-    'Second EnsureView call should not raise');
+  try
+    _CreateSummaryView;
+    Assert.IsTrue(True);
+  except
+    on E: Exception do
+      Assert.Fail('Second EnsureView call raised: ' + E.Message);
+  end;
 end;
 
 // CA-006 Test 3: GET on view resource returns data

--- a/Test/Delphi/Tests/TestJanusRESTJoinView.pas
+++ b/Test/Delphi/Tests/TestJanusRESTJoinView.pas
@@ -59,6 +59,7 @@ const
 
 procedure TTestRESTJoinView.Setup;
 begin
+  FPrefix := 'api/Janus';
   inherited Setup;
   FHTTPClient := THTTPClient.Create;
   FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
@@ -75,7 +76,7 @@ end;
 function TTestRESTJoinView._BuildURL(const AResource: String;
   const AQuery: String): String;
 begin
-  Result := Format('http://localhost:%d/api/Janus/%s', [Port, AResource]);
+  Result := BuildResourceURL(AResource);
   if AQuery <> '' then
     Result := Result + '?' + AQuery;
 end;

--- a/Test/Delphi/Tests/TestJanusRESTJoinView.pas
+++ b/Test/Delphi/Tests/TestJanusRESTJoinView.pas
@@ -28,6 +28,8 @@ type
     procedure _SeedOrderData;
     procedure _CreateSummaryView;
   public
+    [SetupFixture]
+    procedure SetupFixture;
     [Setup]
     procedure Setup;
     [TearDown]
@@ -58,9 +60,14 @@ const
 
 { TTestRESTJoinView }
 
-procedure TTestRESTJoinView.Setup;
+procedure TTestRESTJoinView.SetupFixture;
 begin
   FPrefix := 'api/Janus';
+  inherited SetupFixture;
+end;
+
+procedure TTestRESTJoinView.Setup;
+begin
   inherited Setup;
   FHTTPClient := THTTPClient.Create;
   FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;

--- a/Test/Delphi/Tests/TestJanusRESTMethodGrant.pas
+++ b/Test/Delphi/Tests/TestJanusRESTMethodGrant.pas
@@ -26,6 +26,8 @@ type
     function _PutStatusCode(const AURL: String; const ABody: String): Integer;
     function _DeleteStatusCode(const AURL: String): Integer;
   public
+    [SetupFixture]
+    procedure SetupFixture;
     [Setup]
     procedure Setup;
     [TearDown]
@@ -83,9 +85,14 @@ const
 
 { TTestRESTMethodGrant }
 
-procedure TTestRESTMethodGrant.Setup;
+procedure TTestRESTMethodGrant.SetupFixture;
 begin
   FPrefix := 'api/Janus';
+  inherited SetupFixture;
+end;
+
+procedure TTestRESTMethodGrant.Setup;
+begin
   inherited Setup;
   FHTTPClient := THTTPClient.Create;
   FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;

--- a/Test/Delphi/Tests/TestJanusRESTMethodGrant.pas
+++ b/Test/Delphi/Tests/TestJanusRESTMethodGrant.pas
@@ -1,0 +1,347 @@
+unit TestJanusRESTMethodGrant;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  Net.HTTPClient,
+  Net.URLClient,
+  DUnitX.TestFramework,
+  RestHorseTest.Base,
+  RestHorseTest.Models;
+
+type
+  [TestFixture]
+  TTestRESTMethodGrant = class(TRestHorseTestBase)
+  private
+    FHTTPClient: THTTPClient;
+    function _BuildURL(const AResource: String): String;
+    function _Get(const AURL: String): String;
+    function _Post(const AURL: String; const ABody: String): String;
+    function _Put(const AURL: String; const ABody: String): String;
+    function _Delete(const AURL: String): String;
+    function _GetStatusCode(const AURL: String): Integer;
+    function _PostStatusCode(const AURL: String; const ABody: String): Integer;
+    function _PutStatusCode(const AURL: String; const ABody: String): Integer;
+    function _DeleteStatusCode(const AURL: String): Integer;
+  public
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    // CA-005: [RESTAllowGET] only — POST/PUT/DELETE blocked
+    [Test]
+    procedure GETOnly_Get_Succeeds;
+    [Test]
+    procedure GETOnly_Post_ReturnsVerbNotAllowedError;
+    [Test]
+    procedure GETOnly_Put_ReturnsVerbNotAllowedError;
+    [Test]
+    procedure GETOnly_Delete_ReturnsVerbNotAllowedError;
+
+    // CA-006: [RESTAllowGET] + [RESTAllowPOST] — GET and POST succeed; PUT/DELETE blocked
+    [Test]
+    procedure GETAndPOST_Get_Succeeds;
+    [Test]
+    procedure GETAndPOST_Post_Succeeds;
+    [Test]
+    procedure GETAndPOST_Put_ReturnsVerbNotAllowedError;
+    [Test]
+    procedure GETAndPOST_Delete_ReturnsVerbNotAllowedError;
+
+    // CA-007: all four [RESTAllow*] — all verbs pass
+    [Test]
+    procedure FullAllow_Get_Succeeds;
+    [Test]
+    procedure FullAllow_Post_Succeeds;
+    [Test]
+    procedure FullAllow_Put_Succeeds;
+    [Test]
+    procedure FullAllow_Delete_Succeeds;
+
+    // CA-008: [RESTReadOnly] + [RESTAllowPOST] — [RESTReadOnly] wins
+    [Test]
+    procedure ReadOnlyWithPOST_Get_Succeeds;
+    [Test]
+    procedure ReadOnlyWithPOST_Post_ReturnsReadOnlyError;
+
+    // CA-009: no attribute — all verbs pass (unchanged behavior)
+    [Test]
+    procedure NoAttribute_Get_Succeeds;
+    [Test]
+    procedure NoAttribute_Post_Succeeds;
+  end;
+
+implementation
+
+const
+  cTIMEOUT_MS = 2000;
+  cVERBNOTALLOWED_FRAGMENT = 'not allowed for';
+  cREADONLY_MSG = 'read-only (RESTReadOnly)';
+
+{ TTestRESTMethodGrant }
+
+procedure TTestRESTMethodGrant.Setup;
+begin
+  FPrefix := 'api/Janus';
+  inherited Setup;
+  FHTTPClient := THTTPClient.Create;
+  FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
+  FHTTPClient.ResponseTimeout := cTIMEOUT_MS;
+  SeedCustomers;
+  ExecuteSQL('INSERT INTO grant_get_only_test (name) VALUES (''Seed'')');
+  ExecuteSQL('INSERT INTO grant_full_allow_test (name) VALUES (''Seed'')');
+end;
+
+procedure TTestRESTMethodGrant.TearDown;
+begin
+  FreeAndNil(FHTTPClient);
+  inherited TearDown;
+end;
+
+function TTestRESTMethodGrant._BuildURL(const AResource: String): String;
+begin
+  Result := BuildResourceURL(AResource);
+end;
+
+function TTestRESTMethodGrant._Get(const AURL: String): String;
+begin
+  Result := FHTTPClient.Get(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestRESTMethodGrant._Post(const AURL: String; const ABody: String): String;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')])
+      .ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTMethodGrant._Put(const AURL: String; const ABody: String): String;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Put(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')])
+      .ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTMethodGrant._Delete(const AURL: String): String;
+begin
+  Result := FHTTPClient.Delete(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestRESTMethodGrant._GetStatusCode(const AURL: String): Integer;
+begin
+  Result := FHTTPClient.Get(AURL).StatusCode;
+end;
+
+function TTestRESTMethodGrant._PostStatusCode(const AURL: String;
+  const ABody: String): Integer;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')]).StatusCode;
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTMethodGrant._PutStatusCode(const AURL: String;
+  const ABody: String): Integer;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Put(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')]).StatusCode;
+  finally
+    LStream.Free;
+  end;
+end;
+
+function TTestRESTMethodGrant._DeleteStatusCode(const AURL: String): Integer;
+begin
+  Result := FHTTPClient.Delete(AURL).StatusCode;
+end;
+
+// CA-005: [RESTAllowGET] only
+
+procedure TTestRESTMethodGrant.GETOnly_Get_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('GrantGETOnly'));
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'GET must succeed on [RESTAllowGET] class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.GETOnly_Post_ReturnsVerbNotAllowedError;
+var
+  LResult: String;
+begin
+  LResult := _Post(_BuildURL('GrantGETOnly'), '{"name":"Blocked"}');
+  Assert.IsTrue(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'POST must return verb-not-allowed error, got: ' + LResult);
+  Assert.IsTrue(LResult.Contains('POST'),
+    'Error message must contain verb name, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.GETOnly_Put_ReturnsVerbNotAllowedError;
+var
+  LResult: String;
+begin
+  LResult := _Put(_BuildURL('GrantGETOnly'), '{"id":1,"name":"Blocked"}');
+  Assert.IsTrue(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'PUT must return verb-not-allowed error, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.GETOnly_Delete_ReturnsVerbNotAllowedError;
+var
+  LResult: String;
+begin
+  LResult := _Delete(_BuildURL('GrantGETOnly(1)'));
+  Assert.IsTrue(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'DELETE must return verb-not-allowed error, got: ' + LResult);
+end;
+
+// CA-006: [RESTAllowGET] + [RESTAllowPOST]
+
+procedure TTestRESTMethodGrant.GETAndPOST_Get_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('GrantGETAndPOST'));
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'GET must succeed on GET+POST class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.GETAndPOST_Post_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Post(_BuildURL('GrantGETAndPOST'), '{"name":"NewRecord"}');
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'POST must succeed on GET+POST class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.GETAndPOST_Put_ReturnsVerbNotAllowedError;
+var
+  LResult: String;
+begin
+  LResult := _Put(_BuildURL('GrantGETAndPOST'), '{"id":1,"name":"Blocked"}');
+  Assert.IsTrue(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'PUT must return verb-not-allowed error, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.GETAndPOST_Delete_ReturnsVerbNotAllowedError;
+var
+  LResult: String;
+begin
+  LResult := _Delete(_BuildURL('GrantGETAndPOST(1)'));
+  Assert.IsTrue(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'DELETE must return verb-not-allowed error, got: ' + LResult);
+end;
+
+// CA-007: all four [RESTAllow*]
+
+procedure TTestRESTMethodGrant.FullAllow_Get_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('GrantFullAllow'));
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'GET must succeed on full-allow class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.FullAllow_Post_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Post(_BuildURL('GrantFullAllow'), '{"name":"NewFull"}');
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'POST must succeed on full-allow class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.FullAllow_Put_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Put(_BuildURL('GrantFullAllow'), '{"id":1,"name":"UpdatedFull"}');
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'PUT must succeed on full-allow class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.FullAllow_Delete_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Delete(_BuildURL('GrantFullAllow(1)'));
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'DELETE must succeed on full-allow class, got: ' + LResult);
+end;
+
+// CA-008: [RESTReadOnly] + [RESTAllowPOST] — RESTReadOnly wins
+
+procedure TTestRESTMethodGrant.ReadOnlyWithPOST_Get_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('GrantReadOnlyWithPOST'));
+  Assert.IsFalse(LResult.Contains(cREADONLY_MSG),
+    'GET must succeed on read-only+POST class, got: ' + LResult);
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'GET must not return verb error, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.ReadOnlyWithPOST_Post_ReturnsReadOnlyError;
+var
+  LResult: String;
+begin
+  LResult := _Post(_BuildURL('GrantReadOnlyWithPOST'), '{"name":"ShouldFail"}');
+  Assert.IsTrue(LResult.Contains(cREADONLY_MSG),
+    '[RESTReadOnly] must win over [RESTAllowPOST], got: ' + LResult);
+end;
+
+// CA-009: no attribute — all verbs pass
+
+procedure TTestRESTMethodGrant.NoAttribute_Get_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Get(_BuildURL('CustomerTest'));
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'GET must pass on no-attribute class, got: ' + LResult);
+end;
+
+procedure TTestRESTMethodGrant.NoAttribute_Post_Succeeds;
+var
+  LResult: String;
+begin
+  LResult := _Post(_BuildURL('CustomerTest'),
+    '{"name":"TestNoAttr","email":"test@test.com","active":true}');
+  Assert.IsFalse(LResult.Contains(cVERBNOTALLOWED_FRAGMENT),
+    'POST must pass on no-attribute class, got: ' + LResult);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestRESTMethodGrant);
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTQueryParse.pas
+++ b/Test/Delphi/Tests/TestJanusRESTQueryParse.pas
@@ -4,8 +4,63 @@ interface
 
 uses
   SysUtils,
+  DB,
   DUnitX.TestFramework,
+  MetaDbDiff.Mapping.Attributes,
+  MetaDbDiff.Mapping.Explorer,
   Janus.Server.RestQuery.Parse;
+
+// Local model stubs for RTTI attribute detection tests
+type
+  [Entity]
+  [Table('rtti_allow_get_stub', '')]
+  [RESTAllowGET]
+  TRTTIAllowGETStub = class
+  end;
+
+  [Entity]
+  [Table('rtti_allow_post_stub', '')]
+  [RESTAllowPOST]
+  TRTTIAllowPOSTStub = class
+  end;
+
+  [Entity]
+  [Table('rtti_allow_put_stub', '')]
+  [RESTAllowPUT]
+  TRTTIAllowPUTStub = class
+  end;
+
+  [Entity]
+  [Table('rtti_allow_delete_stub', '')]
+  [RESTAllowDELETE]
+  TRTTIAllowDELETEStub = class
+  end;
+
+  [Entity]
+  [Table('rtti_no_allow_stub', '')]
+  TRTTINoAllowStub = class
+  end;
+
+type
+  [TestFixture]
+  TTestRESTAllowVerbsRTTI = class
+  public
+    // CA-001
+    [Test]
+    procedure GetRESTAllowVerbs_ClassWithRESTAllowGET_DetectsGET;
+    // CA-002
+    [Test]
+    procedure GetRESTAllowVerbs_ClassWithRESTAllowPOST_DetectsPOST;
+    // CA-003
+    [Test]
+    procedure GetRESTAllowVerbs_ClassWithRESTAllowPUT_DetectsPUT;
+    // CA-004
+    [Test]
+    procedure GetRESTAllowVerbs_ClassWithRESTAllowDELETE_DetectsDELETE;
+    // CA-010: class with no [RESTAllow*] has HasAllowList = False
+    [Test]
+    procedure GetRESTAllowVerbs_ClassWithNoAttribute_HasAllowListFalse;
+  end;
 
 type
   [TestFixture]
@@ -446,7 +501,54 @@ begin
   Assert.AreEqual('id,name,email', FParser.Select);
 end;
 
+{ TTestRESTAllowVerbsRTTI }
+
+procedure TTestRESTAllowVerbsRTTI.GetRESTAllowVerbs_ClassWithRESTAllowGET_DetectsGET;
+var
+  LCache: TRESTAllowVerbCache;
+begin
+  LCache := TMappingExplorer.GetRESTAllowVerbs(TRTTIAllowGETStub);
+  Assert.IsTrue(LCache.HasAllowList, 'HasAllowList must be True for [RESTAllowGET]');
+  Assert.IsTrue(rvGET in LCache.AllowedVerbs, 'rvGET must be in AllowedVerbs');
+end;
+
+procedure TTestRESTAllowVerbsRTTI.GetRESTAllowVerbs_ClassWithRESTAllowPOST_DetectsPOST;
+var
+  LCache: TRESTAllowVerbCache;
+begin
+  LCache := TMappingExplorer.GetRESTAllowVerbs(TRTTIAllowPOSTStub);
+  Assert.IsTrue(LCache.HasAllowList, 'HasAllowList must be True for [RESTAllowPOST]');
+  Assert.IsTrue(rvPOST in LCache.AllowedVerbs, 'rvPOST must be in AllowedVerbs');
+end;
+
+procedure TTestRESTAllowVerbsRTTI.GetRESTAllowVerbs_ClassWithRESTAllowPUT_DetectsPUT;
+var
+  LCache: TRESTAllowVerbCache;
+begin
+  LCache := TMappingExplorer.GetRESTAllowVerbs(TRTTIAllowPUTStub);
+  Assert.IsTrue(LCache.HasAllowList, 'HasAllowList must be True for [RESTAllowPUT]');
+  Assert.IsTrue(rvPUT in LCache.AllowedVerbs, 'rvPUT must be in AllowedVerbs');
+end;
+
+procedure TTestRESTAllowVerbsRTTI.GetRESTAllowVerbs_ClassWithRESTAllowDELETE_DetectsDELETE;
+var
+  LCache: TRESTAllowVerbCache;
+begin
+  LCache := TMappingExplorer.GetRESTAllowVerbs(TRTTIAllowDELETEStub);
+  Assert.IsTrue(LCache.HasAllowList, 'HasAllowList must be True for [RESTAllowDELETE]');
+  Assert.IsTrue(rvDELETE in LCache.AllowedVerbs, 'rvDELETE must be in AllowedVerbs');
+end;
+
+procedure TTestRESTAllowVerbsRTTI.GetRESTAllowVerbs_ClassWithNoAttribute_HasAllowListFalse;
+var
+  LCache: TRESTAllowVerbCache;
+begin
+  LCache := TMappingExplorer.GetRESTAllowVerbs(TRTTINoAllowStub);
+  Assert.IsFalse(LCache.HasAllowList, 'HasAllowList must be False when no [RESTAllow*] present');
+end;
+
 initialization
+  TDUnitX.RegisterTestFixture(TTestRESTAllowVerbsRTTI);
   TDUnitX.RegisterTestFixture(TTestRESTQueryParse);
 
 end.

--- a/Test/Delphi/Tests/TestJanusRESTReadOnly.pas
+++ b/Test/Delphi/Tests/TestJanusRESTReadOnly.pas
@@ -23,6 +23,8 @@ type
     function _Put(const AURL: String; const ABody: String): String;
     function _Delete(const AURL: String): String;
   public
+    [SetupFixture]
+    procedure SetupFixture;
     [Setup]
     procedure Setup;
     [TearDown]
@@ -53,9 +55,14 @@ const
 
 { TTestRESTReadOnly }
 
-procedure TTestRESTReadOnly.Setup;
+procedure TTestRESTReadOnly.SetupFixture;
 begin
   FPrefix := 'api/Janus';
+  inherited SetupFixture;
+end;
+
+procedure TTestRESTReadOnly.Setup;
+begin
   inherited Setup;
   FHTTPClient := THTTPClient.Create;
   FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;

--- a/Test/Delphi/Tests/TestJanusRESTReadOnly.pas
+++ b/Test/Delphi/Tests/TestJanusRESTReadOnly.pas
@@ -55,6 +55,7 @@ const
 
 procedure TTestRESTReadOnly.Setup;
 begin
+  FPrefix := 'api/Janus';
   inherited Setup;
   FHTTPClient := THTTPClient.Create;
   FHTTPClient.ConnectionTimeout := cTIMEOUT_MS;
@@ -70,7 +71,7 @@ end;
 function TTestRESTReadOnly._BuildURL(const AResource: String;
   const AQuery: String): String;
 begin
-  Result := Format('http://localhost:%d/api/Janus/%s', [Port, AResource]);
+  Result := BuildResourceURL(AResource);
   if AQuery <> '' then
     Result := Result + '?' + AQuery;
 end;

--- a/docs-src/docs/janus/rest-readonly.md
+++ b/docs-src/docs/janus/rest-readonly.md
@@ -63,3 +63,84 @@ THorse.Listen(9000);
 |-----------|--------|
 | `[NotServerUse]` | Blocks ALL REST access (GET + write) |
 | `[RESTReadOnly]` | Allows GET; blocks POST/PUT/DELETE |
+
+## Method-level granularity
+
+Four new attributes provide per-HTTP-verb access control using **grant-list semantics**: if any `[RESTAllow*]` attribute is present on a class, only the explicitly listed verbs are allowed. All others return a deterministic JSON error.
+
+### Attribute declarations
+
+```delphi
+uses MetaDbDiff.Mapping.Attributes;
+
+// Allow GET only (e.g. audit log — read but no insert)
+[Entity]
+[Table('audit_log', '')]
+[RESTAllowGET]
+TAuditLog = class
+  // ...
+end;
+
+// Allow GET + POST only (e.g. append-only stream)
+[Entity]
+[Table('event_stream', '')]
+[RESTAllowGET]
+[RESTAllowPOST]
+TEventStream = class
+  // ...
+end;
+
+// Allow all verbs explicitly (equivalent to no restriction)
+[Entity]
+[Table('lookup_item', '')]
+[RESTAllowGET]
+[RESTAllowPOST]
+[RESTAllowPUT]
+[RESTAllowDELETE]
+TLookupItem = class
+  // ...
+end;
+```
+
+### Combined behaviour table
+
+| Attributes present | GET | POST | PUT | DELETE |
+|--------------------|-----|------|-----|--------|
+| _(none)_ | ✔ pass | ✔ pass | ✔ pass | ✔ pass |
+| `[RESTReadOnly]` | ✔ pass | ✗ blocked (read-only) | ✗ blocked (read-only) | ✗ blocked (read-only) |
+| `[RESTAllowGET]` | ✔ pass | ✗ blocked (not allowed) | ✗ blocked (not allowed) | ✗ blocked (not allowed) |
+| `[RESTAllowGET]` + `[RESTAllowPOST]` | ✔ pass | ✔ pass | ✗ blocked (not allowed) | ✗ blocked (not allowed) |
+| All four `[RESTAllow*]` | ✔ pass | ✔ pass | ✔ pass | ✔ pass |
+| `[RESTReadOnly]` + `[RESTAllowPOST]` | ✔ pass | ✗ blocked (read-only wins) | ✗ blocked (read-only wins) | ✗ blocked (read-only wins) |
+
+> **Note:** `[RESTReadOnly]` always takes precedence. Adding `[RESTAllow*]` attributes to a class that also has `[RESTReadOnly]` does not unlock writes.
+
+### Error response format
+
+Blocked verbs return:
+
+```json
+{"exception":"HTTP POST not allowed for TEventStream"}
+```
+
+The class name in the message is the Delphi resource name (with `T` prefix as registered).
+
+### cURL examples — GET-only scenario
+
+```bash
+# GET succeeds
+curl http://localhost:9000/api/Janus/AuditLog
+# → [{"id":1,"..."}]
+
+# POST blocked
+curl -X POST http://localhost:9000/api/Janus/AuditLog \
+     -H "Content-Type: application/json" \
+     -d '{"description":"New entry"}'
+# → {"exception":"HTTP POST not allowed for TAuditLog"}
+```
+
+### Precedence rules
+
+- `[RESTReadOnly]` is checked **first**. If present, all writes are blocked regardless of any `[RESTAllow*]` attributes.
+- `[RESTAllow*]` grant-list is checked **second**, only when `[RESTReadOnly]` is absent.
+- A class with **no** `[RESTAllow*]` and no `[RESTReadOnly]` passes all verbs (unchanged default behaviour).

--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -43,6 +43,15 @@ const sidebars = {
             },
             {
               type: 'category',
+              label: 'RESTful',
+              items: [
+                'janus/odata-reference',
+                'janus/rest-readonly',
+                'janus/rest-join-strategy',
+              ],
+            },
+            {
+              type: 'category',
               label: 'Tests & Support',
               items: ['janus/tests/overview', 'janus/troubleshooting/common-errors'],
             },


### PR DESCRIPTION
Batch release — tasks: #133, #134, #135, #136, #137, #138

## Changes included

- fix: post-release caveat closure for v2.20.0 (#133)
- feat: REST/Horse integration test suite via Driver (#134)
- fix: align FPrefix and `_BuildURL` delegation in RESTReadOnly and RESTJoinView fixtures (#135)
- docs: consolidate pre-release v2.20.1 artifacts — changelog and roadmap (#136)
- feat: add RESTAllowGET/POST/PUT/DELETE per-verb grant-list access control (#137)
- fix: fix AV failures by migrating Horse server lifecycle to per-fixture SetupFixture/TearDownFixture (#138)

## QA status

- Review: APPROVED WITH CAVEATS
- Test: APPROVED WITH CAVEATS (45/48 pass; 3 pre-existing behavioral failures confirmed by reviewer)