### PR TITLE
release: merge develop into main

### DIFF
--- a/Examples/Delphi/Livebindings/FMX/UPrincipal.pas
+++ b/Examples/Delphi/Livebindings/FMX/UPrincipal.pas
@@ -1,3 +1,17 @@
+// ============================================================
+// FMX MIGRATION NOTE (R22.5 / 2026-04-26)
+// ------------------------------------------------------------
+// Este exemplo ainda usa o engine legado (TJanusLiveBindings +
+// Janus.FMX.Controls). Os símbolos legados foram marcados como
+// deprecated no R22.4 e serão removidos no R22.6.
+//
+// A migração completa para TJanusBinder em FMX requer suporte
+// a unidades FMX condicionais em Janus.Binder.pas, previsto para
+// um ciclo futuro. Consulte o exemplo VCL migrado em:
+//   Examples/Delphi/Livebindings/VCL/
+// e o guia em:
+//   docs-src/docs/janus/user/guides/livebindings.md
+// ============================================================
 unit UPrincipal;
 
 interface

--- a/Examples/Delphi/Livebindings/FMX/produto.pas
+++ b/Examples/Delphi/Livebindings/FMX/produto.pas
@@ -1,3 +1,17 @@
+// ============================================================
+// FMX MIGRATION NOTE (R22.5 / 2026-04-26)
+// ------------------------------------------------------------
+// Este exemplo ainda usa o engine legado (TJanusLiveBindings +
+// Janus.FMX.Controls). Os símbolos legados foram marcados como
+// deprecated no R22.4 e serão removidos no R22.6.
+//
+// A migração completa para TJanusBinder em FMX requer suporte
+// a unidades FMX condicionais em Janus.Binder.pas, previsto para
+// um ciclo futuro. Consulte o exemplo VCL migrado em:
+//   Examples/Delphi/Livebindings/VCL/
+// e o guia em:
+//   docs-src/docs/janus/user/guides/livebindings.md
+// ============================================================
 unit produto;
 
 interface

--- a/Examples/Delphi/Livebindings/VCL/Janus_LivebindingsVCL.dpr
+++ b/Examples/Delphi/Livebindings/VCL/Janus_LivebindingsVCL.dpr
@@ -4,9 +4,8 @@ uses
   Vcl.Forms,
   UPrincipal in 'UPrincipal.pas' {FormPrincipal},
   produto in 'produto.pas',
-  Janus.Controls.Helpers in '..\..\..\Source\Livebindings\Janus.Controls.Helpers.pas',
-  Janus.LiveBindings in '..\..\..\Source\Livebindings\Janus.LiveBindings.pas',
-  Janus.VCL.Controls in '..\..\..\Source\Livebindings\Janus.VCL.Controls.pas';
+  Janus.Binder.Attributes in '..\..\..\Source\Livebindings\Janus.Binder.Attributes.pas',
+  Janus.Binder in '..\..\..\Source\Livebindings\Janus.Binder.pas';
 
 {$R *.res}
 

--- a/Examples/Delphi/Livebindings/VCL/Janus_LivebindingsVCL.dproj
+++ b/Examples/Delphi/Livebindings/VCL/Janus_LivebindingsVCL.dproj
@@ -108,9 +108,8 @@
             <FormType>dfm</FormType>
         </DCCReference>
         <DCCReference Include="produto.pas"/>
-        <DCCReference Include="..\..\..\Source\Livebindings\Janus.Controls.Helpers.pas"/>
-        <DCCReference Include="..\..\..\Source\Livebindings\Janus.LiveBindings.pas"/>
-        <DCCReference Include="..\..\..\Source\Livebindings\Janus.VCL.Controls.pas"/>
+        <DCCReference Include="..\..\..\Source\Livebindings\Janus.Binder.Attributes.pas"/>
+        <DCCReference Include="..\..\..\Source\Livebindings\Janus.Binder.pas"/>
         <BuildConfiguration Include="Release">
             <Key>Cfg_2</Key>
             <CfgParent>Base</CfgParent>

--- a/Examples/Delphi/Livebindings/VCL/UPrincipal.pas
+++ b/Examples/Delphi/Livebindings/VCL/UPrincipal.pas
@@ -15,12 +15,7 @@ uses
   Vcl.StdCtrls,
   Vcl.ComCtrls,
 
-  produto,
-  // ESSA UNIT TEM QUE ESTAR AQUI POR ULTIMO EM TODOS OS FORMULARIOS,
-  // SEN�O N�O FUNCIONA.
-  //
-  // N�O COLOCAR NO IMPLEMENTATION, TEM QUE SER AQU NA INTERFACE MESMO E POR �LTIMO.
-  Janus.VCL.Controls;
+  produto;
 
 type
   TFormPrincipal = class(TForm)
@@ -44,6 +39,7 @@ type
   private
     { Private declarations }
     FProduto_1: TProduto;
+    FBinder: TJanusBinder;
   public
     { Public declarations }
   end;
@@ -52,6 +48,9 @@ var
   FormPrincipal: TFormPrincipal;
 
 implementation
+
+uses
+  Janus.Binder;
 
 {$R *.dfm}
 
@@ -69,6 +68,7 @@ procedure TFormPrincipal.Button3Click(Sender: TObject);
 begin
   FProduto_1.ID := FProduto_1.ID * 2;
   FProduto_1.Preco := FProduto_1.Preco * 4.5;
+  FBinder.Refresh;
 end;
 
 procedure TFormPrincipal.Button4Click(Sender: TObject);
@@ -79,13 +79,17 @@ end;
 procedure TFormPrincipal.FormCreate(Sender: TObject);
 begin
   FProduto_1 := TProduto.Create;
-  // Valor padr�o, j� ser� mostrado nos componentes
+  FBinder := TJanusBinder.Create(Self);
+  FBinder.Bind(FProduto_1);
   FProduto_1.ID := 1;
   FProduto_1.Preco := 10;
+  FBinder.Refresh;
+  EditSoma.ReadOnly := True;
 end;
 
 procedure TFormPrincipal.FormDestroy(Sender: TObject);
 begin
+  FBinder.Free;
   FProduto_1.Free;
 end;
 

--- a/Examples/Delphi/Livebindings/VCL/produto.pas
+++ b/Examples/Delphi/Livebindings/VCL/produto.pas
@@ -3,55 +3,45 @@ unit produto;
 interface
 
 uses
-  Janus.LiveBindings;
+  Janus.Binder.Attributes;
 
 type
-  TProduto = class(TJanusLiveBindings)
+  TProduto = class
   private
     FID: Integer;
     FPreco: Double;
     FSoma: Double;
-    procedure SetPreco(const Value: Double);
-    procedure SetID(const Value: Integer);
+    procedure SetID(const AValue: Integer);
+    procedure SetPreco(const AValue: Double);
   public
-    constructor Create; override;
-
-    [LiveBindingsControl('EditID', 'Text')]
-    [LiveBindingsControl('LabelID', 'Caption')]
-    [LiveBindingsControl('ComboEditID', 'ItemIndex')]
-    [LiveBindingsControl('ProgressBarID', 'Position')]
+    [Bind('EditID', 'Text')]
+    [Bind('LabelID', 'Caption')]
+    [Bind('ComboEditID', 'ItemIndex')]
+    [Bind('ProgressBarID', 'Position')]
     property ID: Integer read FID write SetID;
 
-    [LiveBindingsControl('EditPreco', 'Text')]
-    [LiveBindingsControl('LabelPreco', 'Caption')]
+    [Bind('EditPreco', 'Text')]
+    [Bind('LabelPreco', 'Caption')]
     property Preco: Double read FPreco write SetPreco;
 
-    [LiveBindingsControl('EditSoma', 'Text', 'TProduto.ID * TProduto.Preco')]
-    property Soma: Double read FSoma write FSoma;
+    [Bind('EditSoma', 'Text')]
+    property Soma: Double read FSoma;
   end;
 
 implementation
 
-uses
-  Bindings.Helper;
-
 { TProduto }
 
-constructor TProduto.Create;
+procedure TProduto.SetID(const AValue: Integer);
 begin
-  inherited;
+  FID := AValue;
+  FSoma := FID * FPreco;
 end;
 
-procedure TProduto.SetID(const Value: Integer);
+procedure TProduto.SetPreco(const AValue: Double);
 begin
-  FID := Value;
-  TBindings.Notify(Self, 'ID');
-end;
-
-procedure TProduto.SetPreco(const Value: Double);
-begin
-  FPreco := Value;
-  TBindings.Notify(Self, 'Preco');
+  FPreco := AValue;
+  FSoma := FID * FPreco;
 end;
 
 end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/JanusOracleRESTServer.dpr
+++ b/Examples/Delphi/RESTful/Horse/Oracle/JanusOracleRESTServer.dpr
@@ -1,0 +1,62 @@
+program JanusOracleRESTServer;
+
+{$APPTYPE CONSOLE}
+{$STRONGLINKTYPES ON}
+
+uses
+  System.SysUtils,
+  System.Classes,
+  FireDAC.ConsoleUI.Wait,
+  FireDAC.Phys.Oracle,
+  FireDAC.Phys.OracleDef,
+  Janus.DML.Generator.Oracle,
+  MetaDbDiff.Mapping.Register,
+  DataEngine.FactoryInterfaces,
+  DataEngine.FactoryFireDAC,
+  Horse,
+  Horse.Core.RouterTree,
+  Janus.Oracle.Model.Cliente     in 'models\Janus.Oracle.Model.Cliente.pas',
+  Janus.Oracle.Model.Produto     in 'models\Janus.Oracle.Model.Produto.pas',
+  Janus.Oracle.Model.Pedido      in 'models\Janus.Oracle.Model.Pedido.pas',
+  Janus.Oracle.Model.PedidosCompletos in 'models\Janus.Oracle.Model.PedidosCompletos.pas',
+  JanusOracle.Interfaces         in 'providers\JanusOracle.Interfaces.pas',
+  DM.Oracle.Connection           in 'providers\DM.Oracle.Connection.pas',
+  JanusOracle.Provider           in 'providers\JanusOracle.Provider.pas';
+
+procedure _RegisterModels;
+begin
+  TRegisterClass.RegisterEntity(TModelCliente);
+  TRegisterClass.RegisterEntity(TModelProduto);
+  TRegisterClass.RegisterEntity(TModelPedido);
+  TRegisterClass.RegisterEntity(TModelPedidosCompletos);
+end;
+
+var
+  LProvider: IProvider;
+  LThread: TThread;
+  LOldRoutes: THorseRouterTree;
+  LNewRoutes: THorseRouterTree;
+begin
+  IsMultiThread := True;
+  _RegisterModels;
+  LProvider := TProviderOracleJanus.Create;
+  LThread := TThread.CreateAnonymousThread(
+    procedure
+    begin
+      THorse.Listen(9100);
+    end);
+  LThread.FreeOnTerminate := True;
+  LThread.Start;
+  Sleep(300);
+  Writeln('=== JanusOracleRESTServer ===');
+  Writeln('Server : http://127.0.0.1:9100/api/Janus');
+  Writeln('View   : vw_pedidos_completos auto-created via TRESTViewManager');
+  Writeln('Press ENTER to exit...');
+  Readln;
+  THorse.StopListen;
+  LOldRoutes := THorse.Routes;
+  LNewRoutes := THorseRouterTree.Create;
+  THorse.Routes := LNewRoutes;
+  LOldRoutes.Free;
+  LProvider := nil;
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.Cliente.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.Cliente.pas
@@ -1,0 +1,42 @@
+unit Janus.Oracle.Model.Cliente;
+
+interface
+
+uses
+  DB,
+  MetaDbDiff.Types.Mapping,
+  MetaDbDiff.Mapping.Attributes;
+
+type
+  [Entity]
+  [Table('clientes', '')]
+  [PrimaryKey('id_cliente', 'Client primary key')]
+  TModelCliente = class
+  private
+    FIdCliente: Integer;
+    FNome: String;
+    FEmail: String;
+    FCidade: String;
+    FDataCadastro: TDate;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id_cliente', ftInteger)]
+    property IdCliente: Integer read FIdCliente write FIdCliente;
+
+    [Restrictions([NotNull])]
+    [Column('nome', ftString, 100)]
+    property Nome: String read FNome write FNome;
+
+    [Column('email', ftString, 100)]
+    property Email: String read FEmail write FEmail;
+
+    [Column('cidade', ftString, 50)]
+    property Cidade: String read FCidade write FCidade;
+
+    [Column('data_cadastro', ftDate)]
+    property DataCadastro: TDate read FDataCadastro write FDataCadastro;
+  end;
+
+implementation
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.Pedido.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.Pedido.pas
@@ -1,0 +1,51 @@
+unit Janus.Oracle.Model.Pedido;
+
+interface
+
+uses
+  DB,
+  MetaDbDiff.Types.Mapping,
+  MetaDbDiff.Mapping.Attributes;
+
+type
+  [Entity]
+  [Table('pedidos', '')]
+  [PrimaryKey('id_pedido', 'Order primary key')]
+  TModelPedido = class
+  private
+    FIdPedido: Integer;
+    FIdCliente: Integer;
+    FIdProduto: Integer;
+    FQuantidade: Integer;
+    FValorTotal: Double;
+    FDataPedido: TDate;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id_pedido', ftInteger)]
+    property IdPedido: Integer read FIdPedido write FIdPedido;
+
+    [Restrictions([NotNull])]
+    [Column('id_cliente', ftInteger)]
+    [ForeignKey('FK_PED_CLI', 'id_cliente', 'clientes', 'id_cliente')]
+    property IdCliente: Integer read FIdCliente write FIdCliente;
+
+    [Restrictions([NotNull])]
+    [Column('id_produto', ftInteger)]
+    [ForeignKey('FK_PED_PRO', 'id_produto', 'produtos', 'id_produto')]
+    property IdProduto: Integer read FIdProduto write FIdProduto;
+
+    [Restrictions([NotNull])]
+    [Column('quantidade', ftInteger)]
+    property Quantidade: Integer read FQuantidade write FQuantidade;
+
+    [Restrictions([NotNull])]
+    [Column('valor_total', ftFloat)]
+    property ValorTotal: Double read FValorTotal write FValorTotal;
+
+    [Column('data_pedido', ftDate)]
+    property DataPedido: TDate read FDataPedido write FDataPedido;
+  end;
+
+implementation
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.PedidosCompletos.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.PedidosCompletos.pas
@@ -1,0 +1,66 @@
+unit Janus.Oracle.Model.PedidosCompletos;
+
+interface
+
+uses
+  DB,
+  MetaDbDiff.Types.Mapping,
+  MetaDbDiff.Mapping.Attributes;
+
+type
+  [Entity]
+  [Table('vw_pedidos_completos', '')]
+  [PrimaryKey('id_pedido', 'Order identifier in view')]
+  [RESTReadOnly]
+  TModelPedidosCompletos = class
+  private
+    FIdPedido: Integer;
+    FDataPedido: TDate;
+    FIdCliente: Integer;
+    FClienteNome: String;
+    FClienteCidade: String;
+    FIdProduto: Integer;
+    FProdutoDescricao: String;
+    FProdutoCategoria: String;
+    FProdutoPreco: Double;
+    FQuantidade: Integer;
+    FValorTotal: Double;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id_pedido', ftInteger)]
+    property IdPedido: Integer read FIdPedido write FIdPedido;
+
+    [Column('data_pedido', ftDate)]
+    property DataPedido: TDate read FDataPedido write FDataPedido;
+
+    [Column('id_cliente', ftInteger)]
+    property IdCliente: Integer read FIdCliente write FIdCliente;
+
+    [Column('cliente_nome', ftString, 100)]
+    property ClienteNome: String read FClienteNome write FClienteNome;
+
+    [Column('cliente_cidade', ftString, 50)]
+    property ClienteCidade: String read FClienteCidade write FClienteCidade;
+
+    [Column('id_produto', ftInteger)]
+    property IdProduto: Integer read FIdProduto write FIdProduto;
+
+    [Column('produto_descricao', ftString, 200)]
+    property ProdutoDescricao: String read FProdutoDescricao write FProdutoDescricao;
+
+    [Column('produto_categoria', ftString, 50)]
+    property ProdutoCategoria: String read FProdutoCategoria write FProdutoCategoria;
+
+    [Column('produto_preco', ftFloat)]
+    property ProdutoPreco: Double read FProdutoPreco write FProdutoPreco;
+
+    [Column('quantidade', ftInteger)]
+    property Quantidade: Integer read FQuantidade write FQuantidade;
+
+    [Column('valor_total', ftFloat)]
+    property ValorTotal: Double read FValorTotal write FValorTotal;
+  end;
+
+implementation
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.PedidosCompletos.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.PedidosCompletos.pas
@@ -9,6 +9,7 @@ uses
 
 type
   [Entity]
+  [View('vw_pedidos_completos', '')]
   [Table('vw_pedidos_completos', '')]
   [PrimaryKey('id_pedido', 'Order identifier in view')]
   [RESTReadOnly]

--- a/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.Produto.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/models/Janus.Oracle.Model.Produto.pas
@@ -1,0 +1,39 @@
+unit Janus.Oracle.Model.Produto;
+
+interface
+
+uses
+  DB,
+  MetaDbDiff.Types.Mapping,
+  MetaDbDiff.Mapping.Attributes;
+
+type
+  [Entity]
+  [Table('produtos', '')]
+  [PrimaryKey('id_produto', 'Product primary key')]
+  TModelProduto = class
+  private
+    FIdProduto: Integer;
+    FDescricao: String;
+    FPreco: Double;
+    FCategoria: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id_produto', ftInteger)]
+    property IdProduto: Integer read FIdProduto write FIdProduto;
+
+    [Restrictions([NotNull])]
+    [Column('descricao', ftString, 200)]
+    property Descricao: String read FDescricao write FDescricao;
+
+    [Restrictions([NotNull])]
+    [Column('preco', ftFloat)]
+    property Preco: Double read FPreco write FPreco;
+
+    [Column('categoria', ftString, 50)]
+    property Categoria: String read FCategoria write FCategoria;
+  end;
+
+implementation
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/providers/DM.Oracle.Connection.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/providers/DM.Oracle.Connection.pas
@@ -1,0 +1,48 @@
+unit DM.Oracle.Connection;
+
+interface
+
+uses
+  System.SysUtils,
+  System.Classes,
+  Data.DB,
+  FireDAC.Comp.Client,
+  FireDAC.Stan.Intf,
+  FireDAC.Stan.Option,
+  FireDAC.Stan.Def,
+  FireDAC.Phys,
+  FireDAC.Phys.Oracle,
+  FireDAC.Phys.OracleDef,
+  FireDAC.ConsoleUI.Wait;
+
+type
+  TOracleProviderDM = class(TDataModule)
+  public
+    FDConnection1: TFDConnection;
+    constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+  end;
+
+implementation
+
+constructor TOracleProviderDM.Create(AOwner: TComponent);
+begin
+  inherited Create(AOwner);
+  FDConnection1 := TFDConnection.Create(nil);
+  FDConnection1.Params.DriverID := 'Ora';
+  FDConnection1.Params.Values['Server'] := 'localhost';
+  FDConnection1.Params.Values['Port'] := '1521';
+  FDConnection1.Params.Values['Database'] := 'XE';
+  FDConnection1.Params.Values['User_Name'] := 'LOCAL';
+  FDConnection1.Params.Values['Password'] := 'local';
+  FDConnection1.Connected := True;
+end;
+
+destructor TOracleProviderDM.Destroy;
+begin
+  FDConnection1.Connected := False;
+  FreeAndNil(FDConnection1);
+  inherited;
+end;
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/providers/JanusOracle.Interfaces.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/providers/JanusOracle.Interfaces.pas
@@ -1,0 +1,12 @@
+unit JanusOracle.Interfaces;
+
+interface
+
+type
+  IProvider = interface
+    ['{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}']
+  end;
+
+implementation
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/providers/JanusOracle.Provider.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/providers/JanusOracle.Provider.pas
@@ -1,0 +1,68 @@
+unit JanusOracle.Provider;
+
+interface
+
+uses
+  System.SysUtils,
+  System.Classes,
+  DataEngine.FactoryInterfaces,
+  DataEngine.FactoryFireDAC,
+  Janus.DML.Generator.Oracle,
+  Janus.Server.Horse,
+  Janus.Server.RestView.Manager,
+  FluentSQL,
+  FluentSQL.Interfaces,
+  DM.Oracle.Connection,
+  JanusOracle.Interfaces,
+  Janus.Oracle.Model.PedidosCompletos;
+
+type
+  TProviderOracleJanus = class(TInterfacedObject, IProvider)
+  private
+    FRESTServerHorse: TRESTServerHorse;
+    FConnection: IDBConnection;
+    FProviderDM: TOracleProviderDM;
+  public
+    constructor Create;
+    destructor Destroy; override;
+  end;
+
+implementation
+
+{ TProviderOracleJanus }
+
+constructor TProviderOracleJanus.Create;
+var
+  LSelect: IFluentSQL;
+begin
+  FProviderDM := TOracleProviderDM.Create(nil);
+  FConnection := TFactoryFireDAC.Create(FProviderDM.FDConnection1, dnOracle);
+  LSelect := FluentSQL.Query(dbnOracle)
+    .Select('p.id_pedido')
+    .Select('p.data_pedido')
+    .Select('c.id_cliente')
+    .Select('c.nome AS cliente_nome')
+    .Select('c.cidade AS cliente_cidade')
+    .Select('pr.id_produto')
+    .Select('pr.descricao AS produto_descricao')
+    .Select('pr.categoria AS produto_categoria')
+    .Select('pr.preco AS produto_preco')
+    .Select('p.quantidade')
+    .Select('p.valor_total')
+    .From('pedidos p')
+    .InnerJoin('clientes c')
+    .OnCond('c.id_cliente = p.id_cliente')
+    .InnerJoin('produtos pr')
+    .OnCond('pr.id_produto = p.id_produto');
+  TRESTViewManager.EnsureView(TModelPedidosCompletos, LSelect, FConnection);
+  FRESTServerHorse := TRESTServerHorse.Create(nil, FConnection, 'api/Janus');
+end;
+
+destructor TProviderOracleJanus.Destroy;
+begin
+  FreeAndNil(FRESTServerHorse);
+  FreeAndNil(FProviderDM);
+  inherited;
+end;
+
+end.

--- a/Examples/Delphi/RESTful/Horse/Oracle/providers/JanusOracle.Provider.pas
+++ b/Examples/Delphi/RESTful/Horse/Oracle/providers/JanusOracle.Provider.pas
@@ -54,7 +54,11 @@ begin
     .OnCond('c.id_cliente = p.id_cliente')
     .InnerJoin('produtos pr')
     .OnCond('pr.id_produto = p.id_produto');
-  TRESTViewManager.EnsureView(TModelPedidosCompletos, LSelect, FConnection);
+  TRESTViewManager.Register(TModelPedidosCompletos,
+    function: IFluentSQL
+    begin
+      Result := LSelect;
+    end);
   FRESTServerHorse := TRESTServerHorse.Create(nil, FConnection, 'api/Janus');
 end;
 

--- a/Source/Livebindings/Janus.Binder.Attributes.pas
+++ b/Source/Livebindings/Janus.Binder.Attributes.pas
@@ -1,0 +1,110 @@
+{
+                   Copyright (c) 2016, Isaque Pinheiro
+                          All rights reserved.
+
+                    GNU Lesser General Public License
+                      Versão 3, 29 de junho de 2007
+
+       Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+       A todos é permitido copiar e distribuir cópias deste documento de
+       licença, mas mudá-lo não é permitido.
+
+       Esta versão da GNU Lesser General Public License incorpora
+       os termos e condições da versão 3 da GNU General Public License
+       Licença, complementado pelas permissões adicionais listadas no
+       arquivo LICENSE na pasta principal.
+}
+
+{ @abstract(Janus Binder Attributes — R22.1)
+  @created(23 Apr 2026)
+  @author(Isaque Pinheiro <isaquepsp@gmail.com>)
+}
+
+unit Janus.Binder.Attributes;
+
+interface
+
+{$IFDEF DCC}
+
+uses
+  System.Classes;
+
+type
+  Bind = class(TCustomAttribute)
+  private
+    FControlName: string;
+    FFieldName: string;
+  public
+    constructor Create(const AControlName, AFieldName: string);
+    property ControlName: string read FControlName;
+    property FieldName: string read FFieldName;
+  end;
+
+  BindGrid = class(TCustomAttribute)
+  private
+    FGridName: string;
+  public
+    constructor Create(const AGridName: string);
+    property GridName: string read FGridName;
+  end;
+
+  BindGridDetail = class(TCustomAttribute)
+  private
+    FGridName: string;
+    FMasterProperty: string;
+  public
+    constructor Create(const AGridName: string; const AMasterProperty: string);
+    property GridName: string read FGridName;
+    property MasterProperty: string read FMasterProperty;
+  end;
+
+  BindListControl = class(TCustomAttribute)
+  private
+    FControlName: string;
+    FFieldName: string;
+  public
+    constructor Create(const AControlName, AFieldName: string);
+    property ControlName: string read FControlName;
+    property FieldName: string read FFieldName;
+  end;
+
+{$ENDIF DCC}
+
+implementation
+
+{$IFDEF DCC}
+
+{ Bind }
+
+constructor Bind.Create(const AControlName, AFieldName: string);
+begin
+  FControlName := AControlName;
+  FFieldName := AFieldName;
+end;
+
+{ BindGrid }
+
+constructor BindGrid.Create(const AGridName: string);
+begin
+  FGridName := AGridName;
+end;
+
+{ BindGridDetail }
+
+constructor BindGridDetail.Create(const AGridName: string; const AMasterProperty: string);
+begin
+  FGridName := AGridName;
+  FMasterProperty := AMasterProperty;
+end;
+
+{ BindListControl }
+
+constructor BindListControl.Create(const AControlName, AFieldName: string);
+begin
+  FControlName := AControlName;
+  FFieldName := AFieldName;
+end;
+
+{$ENDIF DCC}
+
+end.

--- a/Source/Livebindings/Janus.Binder.Resolver.pas
+++ b/Source/Livebindings/Janus.Binder.Resolver.pas
@@ -1,0 +1,51 @@
+{
+                   Copyright (c) 2016, Isaque Pinheiro
+                          All rights reserved.
+
+                    GNU Lesser General Public License
+                      Versão 3, 29 de junho de 2007
+
+       Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+       A todos é permitido copiar e distribuir cópias deste documento de
+       licença, mas mudá-lo não é permitido.
+
+       Esta versão da GNU Lesser General Public License incorpora
+       os termos e condições da versão 3 da GNU General Public License
+       Licença, complementado pelas permissões adicionais listadas no
+       arquivo LICENSE na pasta principal.
+}
+
+{ @abstract(Janus Binder Resolver — R22.1)
+  @created(23 Apr 2026)
+  @author(Isaque Pinheiro <isaquepsp@gmail.com>)
+}
+
+unit Janus.Binder.Resolver;
+
+interface
+
+{$IFDEF DCC}
+
+uses
+  System.Classes;
+
+type
+  TJanusBinderResolver = class
+  public
+    class function Resolve(const AOwner: TComponent; const AName: string): TComponent;
+  end;
+
+{$ENDIF DCC}
+
+implementation
+
+{$IFDEF DCC}
+
+class function TJanusBinderResolver.Resolve(const AOwner: TComponent; const AName: string): TComponent;
+begin
+  Result := AOwner.FindComponent(AName);
+end;
+
+{$ENDIF DCC}
+
+end.

--- a/Source/Livebindings/Janus.Binder.pas
+++ b/Source/Livebindings/Janus.Binder.pas
@@ -15,7 +15,7 @@
        arquivo LICENSE na pasta principal.
 }
 
-{ @abstract(Janus Binder — R22.2 Object backend: simple controls + grid binding)
+{ @abstract(Janus Binder — R22.3 DataSet backend: TBindSourceDB + grid + master-detail)
   @created(23 Apr 2026)
   @author(Isaque Pinheiro <isaquepsp@gmail.com>)
 }
@@ -31,6 +31,8 @@ uses
   System.SysUtils,
   System.Rtti,
   System.Generics.Collections,
+  Data.DB,
+  Data.Bind.DBScope,
   Data.Bind.ObjectScope,
   Data.Bind.Components,
   Data.Bind.Grid,
@@ -66,6 +68,9 @@ type
     FGridListAdapters: TObjectList<TObject>;
     FGridBindSources: TObjectList<TAdapterBindSource>;
     FGridLinks: TObjectList<TLinkGridToDataSource>;
+    FDataSources: TObjectList<TDataSource>;
+    FDBBindSources: TObjectList<TBindSourceDB>;
+    procedure _BindDataSetToGrid(ADataSet: TDataSet; const AGridName: string);
   public
     constructor Create(const AOwner: TComponent);
     destructor Destroy; override;
@@ -86,10 +91,20 @@ type
       const ADetailGridName: string;
       const AGetSubdetail: TJanusChildListFunc<TDetail, TSubdetail>;
       const ASubdetailGridName: string);
+    procedure BindDataSetGrid(ADataSet: TDataSet; const AGridName: string);
+    procedure BindDataSetMasterDetail(
+      AMasterDS: TDataSet; const AMasterGridName: string;
+      ADetailDS: TDataSet; const ADetailGridName: string);
+    procedure BindDataSetMasterDetailSubdetail(
+      AMasterDS: TDataSet; const AMasterGridName: string;
+      ADetailDS: TDataSet; const ADetailGridName: string;
+      ASubdetailDS: TDataSet; const ASubdetailGridName: string);
     property Adapter: TAdapterBindSource read FAdapter;
     property GridListAdapters: TObjectList<TObject> read FGridListAdapters;
     property GridBindSources: TObjectList<TAdapterBindSource> read FGridBindSources;
     property GridLinks: TObjectList<TLinkGridToDataSource> read FGridLinks;
+    property DBBindSources: TObjectList<TBindSourceDB> read FDBBindSources;
+    property DataSources: TObjectList<TDataSource> read FDataSources;
   end;
 
 {$ENDIF DCC}
@@ -134,11 +149,15 @@ begin
   FGridListAdapters := TObjectList<TObject>.Create(True);
   FGridBindSources := TObjectList<TAdapterBindSource>.Create(True);
   FGridLinks := TObjectList<TLinkGridToDataSource>.Create(True);
+  FDataSources := TObjectList<TDataSource>.Create(True);
+  FDBBindSources := TObjectList<TBindSourceDB>.Create(True);
 end;
 
 destructor TJanusBinder.Destroy;
 begin
   Unbind;
+  FDBBindSources.Free;
+  FDataSources.Free;
   FGridLinks.Free;
   FGridBindSources.Free;
   FGridListAdapters.Free;
@@ -197,10 +216,15 @@ var
   LLink: TLinkPropertyToField;
   LGridLink: TLinkGridToDataSource;
   LBindSource: TAdapterBindSource;
+  LDBSource: TBindSourceDB;
 begin
   for LGridLink in FGridLinks do
     LGridLink.Active := False;
   FGridLinks.Clear;
+  for LDBSource in FDBBindSources do
+    LDBSource.DataSource := nil;
+  FDBBindSources.Clear;
+  FDataSources.Clear;
   for LBindSource in FGridBindSources do
     LBindSource.Active := False;
   FGridBindSources.Clear;
@@ -414,6 +438,60 @@ begin
   LSubdetailGridLink.GridControl := LSubdetailGrid;
   LSubdetailGridLink.Active := True;
   FGridLinks.Add(LSubdetailGridLink);
+end;
+
+procedure TJanusBinder._BindDataSetToGrid(ADataSet: TDataSet;
+  const AGridName: string);
+var
+  LGrid: TComponent;
+  LDataSource: TDataSource;
+  LDBBindSource: TBindSourceDB;
+  LGridLink: TLinkGridToDataSource;
+begin
+  LGrid := TJanusBinderResolver.Resolve(FOwner, AGridName);
+  if LGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [AGridName, FOwner.Name]);
+  if not (LGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [AGridName]);
+  LDataSource := TDataSource.Create(nil);
+  LDataSource.DataSet := ADataSet;
+  FDataSources.Add(LDataSource);
+  LDBBindSource := TBindSourceDB.Create(nil);
+  LDBBindSource.DataSource := LDataSource;
+  FDBBindSources.Add(LDBBindSource);
+  LGridLink := TLinkGridToDataSource.Create(nil);
+  LGridLink.DataSource := LDBBindSource;
+  LGridLink.GridControl := LGrid;
+  LGridLink.Active := True;
+  FGridLinks.Add(LGridLink);
+end;
+
+procedure TJanusBinder.BindDataSetGrid(ADataSet: TDataSet;
+  const AGridName: string);
+begin
+  _BindDataSetToGrid(ADataSet, AGridName);
+end;
+
+procedure TJanusBinder.BindDataSetMasterDetail(
+  AMasterDS: TDataSet; const AMasterGridName: string;
+  ADetailDS: TDataSet; const ADetailGridName: string);
+begin
+  _BindDataSetToGrid(AMasterDS, AMasterGridName);
+  _BindDataSetToGrid(ADetailDS, ADetailGridName);
+end;
+
+procedure TJanusBinder.BindDataSetMasterDetailSubdetail(
+  AMasterDS: TDataSet; const AMasterGridName: string;
+  ADetailDS: TDataSet; const ADetailGridName: string;
+  ASubdetailDS: TDataSet; const ASubdetailGridName: string);
+begin
+  _BindDataSetToGrid(AMasterDS, AMasterGridName);
+  _BindDataSetToGrid(ADetailDS, ADetailGridName);
+  _BindDataSetToGrid(ASubdetailDS, ASubdetailGridName);
 end;
 
 {$ENDIF DCC}

--- a/Source/Livebindings/Janus.Binder.pas
+++ b/Source/Livebindings/Janus.Binder.pas
@@ -1,0 +1,146 @@
+{
+                   Copyright (c) 2016, Isaque Pinheiro
+                          All rights reserved.
+
+                    GNU Lesser General Public License
+                      Versão 3, 29 de junho de 2007
+
+       Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+       A todos é permitido copiar e distribuir cópias deste documento de
+       licença, mas mudá-lo não é permitido.
+
+       Esta versão da GNU Lesser General Public License incorpora
+       os termos e condições da versão 3 da GNU General Public License
+       Licença, complementado pelas permissões adicionais listadas no
+       arquivo LICENSE na pasta principal.
+}
+
+{ @abstract(Janus Binder — R22.1 Object backend, simple controls)
+  @created(23 Apr 2026)
+  @author(Isaque Pinheiro <isaquepsp@gmail.com>)
+}
+
+unit Janus.Binder;
+
+interface
+
+{$IFDEF DCC}
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.Rtti,
+  System.Generics.Collections,
+  Data.Bind.ObjectScope,
+  Data.Bind.Components,
+  Janus.Binder.Attributes,
+  Janus.Binder.Resolver;
+
+type
+  EJanusBinderException = class(Exception);
+
+  TJanusBinder = class
+  private
+    FOwner: TComponent;
+    FAdapter: TAdapterBindSource;
+    FObjectAdapter: TObjectBindSourceAdapter;
+    FLinks: TObjectList<TLinkPropertyToField>;
+  public
+    constructor Create(const AOwner: TComponent);
+    destructor Destroy; override;
+    procedure Bind(const AEntity: TObject);
+    procedure Unbind;
+    procedure Refresh;
+  end;
+
+{$ENDIF DCC}
+
+implementation
+
+{$IFDEF DCC}
+
+{ TJanusBinder }
+
+constructor TJanusBinder.Create(const AOwner: TComponent);
+begin
+  FOwner := AOwner;
+  FLinks := TObjectList<TLinkPropertyToField>.Create(True);
+end;
+
+destructor TJanusBinder.Destroy;
+begin
+  Unbind;
+  FLinks.Free;
+  inherited;
+end;
+
+procedure TJanusBinder.Bind(const AEntity: TObject);
+var
+  LContext: TRttiContext;
+  LType: TRttiType;
+  LProperty: TRttiProperty;
+  LAttribute: TCustomAttribute;
+  LBindAttr: Janus.Binder.Attributes.Bind;
+  LControl: TComponent;
+  LLink: TLinkPropertyToField;
+begin
+  Unbind;
+  FObjectAdapter := TObjectBindSourceAdapter.Create(nil, AEntity, AEntity.ClassType, False);
+  FAdapter := TAdapterBindSource.Create(nil);
+  FAdapter.Adapter := FObjectAdapter;
+  FAdapter.Active := True;
+  LContext := TRttiContext.Create;
+  try
+    LType := LContext.GetType(AEntity.ClassType);
+    if LType = nil then
+      Exit;
+    for LProperty in LType.GetProperties do
+    begin
+      for LAttribute in LProperty.GetAttributes do
+      begin
+        if not (LAttribute is Janus.Binder.Attributes.Bind) then
+          Continue;
+        LBindAttr := Janus.Binder.Attributes.Bind(LAttribute);
+        LControl := TJanusBinderResolver.Resolve(FOwner, LBindAttr.ControlName);
+        if LControl = nil then
+          raise EJanusBinderException.CreateFmt(
+            'Control [%s] not found on owner [%s]',
+            [LBindAttr.ControlName, FOwner.Name]);
+        LLink := TLinkPropertyToField.Create(nil);
+        LLink.DataSource := FAdapter;
+        LLink.FieldName := LProperty.Name;
+        LLink.Component := LControl;
+        LLink.ComponentProperty := LBindAttr.FieldName;
+        LLink.Active := True;
+        FLinks.Add(LLink);
+      end;
+    end;
+  finally
+    LContext.Free;
+  end;
+end;
+
+procedure TJanusBinder.Unbind;
+var
+  LLink: TLinkPropertyToField;
+begin
+  for LLink in FLinks do
+    LLink.Active := False;
+  FLinks.Clear;
+  if Assigned(FAdapter) then
+  begin
+    FAdapter.Active := False;
+    FreeAndNil(FAdapter);
+  end;
+  FreeAndNil(FObjectAdapter);
+end;
+
+procedure TJanusBinder.Refresh;
+begin
+  if Assigned(FAdapter) then
+    FAdapter.Refresh;
+end;
+
+{$ENDIF DCC}
+
+end.

--- a/Source/Livebindings/Janus.Binder.pas
+++ b/Source/Livebindings/Janus.Binder.pas
@@ -15,7 +15,7 @@
        arquivo LICENSE na pasta principal.
 }
 
-{ @abstract(Janus Binder — R22.1 Object backend, simple controls)
+{ @abstract(Janus Binder — R22.2 Object backend: simple controls + grid binding)
   @created(23 Apr 2026)
   @author(Isaque Pinheiro <isaquepsp@gmail.com>)
 }
@@ -33,11 +33,29 @@ uses
   System.Generics.Collections,
   Data.Bind.ObjectScope,
   Data.Bind.Components,
+  Data.Bind.Grid,
+  Vcl.Grids,
   Janus.Binder.Attributes,
   Janus.Binder.Resolver;
 
 type
   EJanusBinderException = class(Exception);
+
+  TJanusChildListFunc<M: class; D: class> =
+    reference to function(const AMaster: M): TObjectList<D>;
+
+  // Bridge object — wraps the scroll-propagation callback as an of-object method.
+  // Stored in FGridListAdapters to tie its lifetime to the binder.
+  TJanusScrollBridge<M: class; D: class> = class
+  private
+    FGetDetail: TJanusChildListFunc<M, D>;
+    FDetailAdapter: TListBindSourceAdapter<D>;
+  public
+    constructor Create(const AGetDetail: TJanusChildListFunc<M, D>;
+      const ADetailAdapter: TListBindSourceAdapter<D>);
+    procedure AfterScroll(AAdapter: TBindSourceAdapter);
+    procedure BeforeScroll(AAdapter: TBindSourceAdapter);
+  end;
 
   TJanusBinder = class
   private
@@ -45,12 +63,33 @@ type
     FAdapter: TAdapterBindSource;
     FObjectAdapter: TObjectBindSourceAdapter;
     FLinks: TObjectList<TLinkPropertyToField>;
+    FGridListAdapters: TObjectList<TObject>;
+    FGridBindSources: TObjectList<TAdapterBindSource>;
+    FGridLinks: TObjectList<TLinkGridToDataSource>;
   public
     constructor Create(const AOwner: TComponent);
     destructor Destroy; override;
     procedure Bind(const AEntity: TObject);
     procedure Unbind;
     procedure Refresh;
+    procedure BindGrid<TItem: class>(const AList: TObjectList<TItem>;
+      const AGridName: string);
+    procedure BindMasterDetail<TMaster: class; TDetail: class>(
+      const AMasterList: TObjectList<TMaster>;
+      const AMasterGridName: string;
+      const AGetDetail: TJanusChildListFunc<TMaster, TDetail>;
+      const ADetailGridName: string);
+    procedure BindMasterDetailSubdetail<TMaster: class; TDetail: class; TSubdetail: class>(
+      const AMasterList: TObjectList<TMaster>;
+      const AMasterGridName: string;
+      const AGetDetail: TJanusChildListFunc<TMaster, TDetail>;
+      const ADetailGridName: string;
+      const AGetSubdetail: TJanusChildListFunc<TDetail, TSubdetail>;
+      const ASubdetailGridName: string);
+    property Adapter: TAdapterBindSource read FAdapter;
+    property GridListAdapters: TObjectList<TObject> read FGridListAdapters;
+    property GridBindSources: TObjectList<TAdapterBindSource> read FGridBindSources;
+    property GridLinks: TObjectList<TLinkGridToDataSource> read FGridLinks;
   end;
 
 {$ENDIF DCC}
@@ -59,17 +98,50 @@ implementation
 
 {$IFDEF DCC}
 
+{ TJanusScrollBridge<M, D> }
+
+constructor TJanusScrollBridge<M, D>.Create(
+  const AGetDetail: TJanusChildListFunc<M, D>;
+  const ADetailAdapter: TListBindSourceAdapter<D>);
+begin
+  FGetDetail := AGetDetail;
+  FDetailAdapter := ADetailAdapter;
+end;
+
+procedure TJanusScrollBridge<M, D>.AfterScroll(AAdapter: TBindSourceAdapter);
+begin
+  if (AAdapter.Current <> nil) and (AAdapter.Current is M) then
+  begin
+    FDetailAdapter.SetList(FGetDetail(M(AAdapter.Current)), False);
+    FDetailAdapter.Active := True;
+  end
+  else
+    FDetailAdapter.SetList(nil, False);
+end;
+
+procedure TJanusScrollBridge<M, D>.BeforeScroll(AAdapter: TBindSourceAdapter);
+begin
+  if FDetailAdapter.State in seEditModes then
+    FDetailAdapter.Post;
+end;
+
 { TJanusBinder }
 
 constructor TJanusBinder.Create(const AOwner: TComponent);
 begin
   FOwner := AOwner;
   FLinks := TObjectList<TLinkPropertyToField>.Create(True);
+  FGridListAdapters := TObjectList<TObject>.Create(True);
+  FGridBindSources := TObjectList<TAdapterBindSource>.Create(True);
+  FGridLinks := TObjectList<TLinkGridToDataSource>.Create(True);
 end;
 
 destructor TJanusBinder.Destroy;
 begin
   Unbind;
+  FGridLinks.Free;
+  FGridBindSources.Free;
+  FGridListAdapters.Free;
   FLinks.Free;
   inherited;
 end;
@@ -123,7 +195,16 @@ end;
 procedure TJanusBinder.Unbind;
 var
   LLink: TLinkPropertyToField;
+  LGridLink: TLinkGridToDataSource;
+  LBindSource: TAdapterBindSource;
 begin
+  for LGridLink in FGridLinks do
+    LGridLink.Active := False;
+  FGridLinks.Clear;
+  for LBindSource in FGridBindSources do
+    LBindSource.Active := False;
+  FGridBindSources.Clear;
+  FGridListAdapters.Clear;
   for LLink in FLinks do
     LLink.Active := False;
   FLinks.Clear;
@@ -139,6 +220,200 @@ procedure TJanusBinder.Refresh;
 begin
   if Assigned(FAdapter) then
     FAdapter.Refresh;
+end;
+
+procedure TJanusBinder.BindGrid<TItem>(const AList: TObjectList<TItem>;
+  const AGridName: string);
+var
+  LGrid: TComponent;
+  LListAdapter: TListBindSourceAdapter<TItem>;
+  LBindSource: TAdapterBindSource;
+  LGridLink: TLinkGridToDataSource;
+begin
+  LGrid := TJanusBinderResolver.Resolve(FOwner, AGridName);
+  if LGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [AGridName, FOwner.Name]);
+  if not (LGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [AGridName]);
+  LListAdapter := TListBindSourceAdapter<TItem>.Create(nil, AList, False);
+  FGridListAdapters.Add(LListAdapter);
+  LBindSource := TAdapterBindSource.Create(nil);
+  LBindSource.Adapter := LListAdapter;
+  LBindSource.Active := True;
+  FGridBindSources.Add(LBindSource);
+  LGridLink := TLinkGridToDataSource.Create(nil);
+  LGridLink.DataSource := LBindSource;
+  LGridLink.GridControl := LGrid;
+  LGridLink.Active := True;
+  FGridLinks.Add(LGridLink);
+end;
+
+procedure TJanusBinder.BindMasterDetail<TMaster, TDetail>(
+  const AMasterList: TObjectList<TMaster>;
+  const AMasterGridName: string;
+  const AGetDetail: TJanusChildListFunc<TMaster, TDetail>;
+  const ADetailGridName: string);
+var
+  LMasterGrid: TComponent;
+  LDetailGrid: TComponent;
+  LMasterAdapter: TListBindSourceAdapter<TMaster>;
+  LDetailPlaceholder: TObjectList<TDetail>;
+  LDetailAdapter: TListBindSourceAdapter<TDetail>;
+  LBridge: TJanusScrollBridge<TMaster, TDetail>;
+  LMasterBindSource: TAdapterBindSource;
+  LMasterGridLink: TLinkGridToDataSource;
+  LDetailBindSource: TAdapterBindSource;
+  LDetailGridLink: TLinkGridToDataSource;
+begin
+  LMasterGrid := TJanusBinderResolver.Resolve(FOwner, AMasterGridName);
+  if LMasterGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [AMasterGridName, FOwner.Name]);
+  if not (LMasterGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [AMasterGridName]);
+  LDetailGrid := TJanusBinderResolver.Resolve(FOwner, ADetailGridName);
+  if LDetailGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [ADetailGridName, FOwner.Name]);
+  if not (LDetailGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [ADetailGridName]);
+  LMasterAdapter := TListBindSourceAdapter<TMaster>.Create(nil, AMasterList, False);
+  FGridListAdapters.Add(LMasterAdapter);
+  LDetailPlaceholder := TObjectList<TDetail>.Create(False);
+  FGridListAdapters.Add(LDetailPlaceholder);
+  LDetailAdapter := TListBindSourceAdapter<TDetail>.Create(nil, LDetailPlaceholder, False);
+  FGridListAdapters.Add(LDetailAdapter);
+  LBridge := TJanusScrollBridge<TMaster, TDetail>.Create(AGetDetail, LDetailAdapter);
+  FGridListAdapters.Add(LBridge);
+  LMasterAdapter.AfterScroll := LBridge.AfterScroll;
+  LMasterAdapter.BeforeScroll := LBridge.BeforeScroll;
+  LMasterBindSource := TAdapterBindSource.Create(nil);
+  LMasterBindSource.Adapter := LMasterAdapter;
+  LMasterBindSource.Active := True;
+  FGridBindSources.Add(LMasterBindSource);
+  LMasterGridLink := TLinkGridToDataSource.Create(nil);
+  LMasterGridLink.DataSource := LMasterBindSource;
+  LMasterGridLink.GridControl := LMasterGrid;
+  LMasterGridLink.Active := True;
+  FGridLinks.Add(LMasterGridLink);
+  LDetailBindSource := TAdapterBindSource.Create(nil);
+  LDetailBindSource.Adapter := LDetailAdapter;
+  LDetailBindSource.Active := True;
+  FGridBindSources.Add(LDetailBindSource);
+  LDetailGridLink := TLinkGridToDataSource.Create(nil);
+  LDetailGridLink.DataSource := LDetailBindSource;
+  LDetailGridLink.GridControl := LDetailGrid;
+  LDetailGridLink.Active := True;
+  FGridLinks.Add(LDetailGridLink);
+end;
+
+procedure TJanusBinder.BindMasterDetailSubdetail<TMaster, TDetail, TSubdetail>(
+  const AMasterList: TObjectList<TMaster>;
+  const AMasterGridName: string;
+  const AGetDetail: TJanusChildListFunc<TMaster, TDetail>;
+  const ADetailGridName: string;
+  const AGetSubdetail: TJanusChildListFunc<TDetail, TSubdetail>;
+  const ASubdetailGridName: string);
+var
+  LMasterGrid: TComponent;
+  LDetailGrid: TComponent;
+  LSubdetailGrid: TComponent;
+  LMasterAdapter: TListBindSourceAdapter<TMaster>;
+  LDetailPlaceholder: TObjectList<TDetail>;
+  LDetailAdapter: TListBindSourceAdapter<TDetail>;
+  LSubdetailPlaceholder: TObjectList<TSubdetail>;
+  LSubdetailAdapter: TListBindSourceAdapter<TSubdetail>;
+  LMasterBridge: TJanusScrollBridge<TMaster, TDetail>;
+  LDetailBridge: TJanusScrollBridge<TDetail, TSubdetail>;
+  LMasterBindSource: TAdapterBindSource;
+  LMasterGridLink: TLinkGridToDataSource;
+  LDetailBindSource: TAdapterBindSource;
+  LDetailGridLink: TLinkGridToDataSource;
+  LSubdetailBindSource: TAdapterBindSource;
+  LSubdetailGridLink: TLinkGridToDataSource;
+begin
+  LMasterGrid := TJanusBinderResolver.Resolve(FOwner, AMasterGridName);
+  if LMasterGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [AMasterGridName, FOwner.Name]);
+  if not (LMasterGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [AMasterGridName]);
+  LDetailGrid := TJanusBinderResolver.Resolve(FOwner, ADetailGridName);
+  if LDetailGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [ADetailGridName, FOwner.Name]);
+  if not (LDetailGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [ADetailGridName]);
+  LSubdetailGrid := TJanusBinderResolver.Resolve(FOwner, ASubdetailGridName);
+  if LSubdetailGrid = nil then
+    raise EJanusBinderException.CreateFmt(
+      'Grid [%s] not found on owner [%s]',
+      [ASubdetailGridName, FOwner.Name]);
+  if not (LSubdetailGrid is TCustomGrid) then
+    raise EJanusBinderException.CreateFmt(
+      'Control [%s] is not a TCustomGrid',
+      [ASubdetailGridName]);
+  LMasterAdapter := TListBindSourceAdapter<TMaster>.Create(nil, AMasterList, False);
+  FGridListAdapters.Add(LMasterAdapter);
+  LDetailPlaceholder := TObjectList<TDetail>.Create(False);
+  FGridListAdapters.Add(LDetailPlaceholder);
+  LDetailAdapter := TListBindSourceAdapter<TDetail>.Create(nil, LDetailPlaceholder, False);
+  FGridListAdapters.Add(LDetailAdapter);
+  LSubdetailPlaceholder := TObjectList<TSubdetail>.Create(False);
+  FGridListAdapters.Add(LSubdetailPlaceholder);
+  LSubdetailAdapter := TListBindSourceAdapter<TSubdetail>.Create(nil, LSubdetailPlaceholder, False);
+  FGridListAdapters.Add(LSubdetailAdapter);
+  LMasterBridge := TJanusScrollBridge<TMaster, TDetail>.Create(AGetDetail, LDetailAdapter);
+  FGridListAdapters.Add(LMasterBridge);
+  LMasterAdapter.AfterScroll := LMasterBridge.AfterScroll;
+  LMasterAdapter.BeforeScroll := LMasterBridge.BeforeScroll;
+  LDetailBridge := TJanusScrollBridge<TDetail, TSubdetail>.Create(AGetSubdetail, LSubdetailAdapter);
+  FGridListAdapters.Add(LDetailBridge);
+  LDetailAdapter.AfterScroll := LDetailBridge.AfterScroll;
+  LDetailAdapter.BeforeScroll := LDetailBridge.BeforeScroll;
+  LMasterBindSource := TAdapterBindSource.Create(nil);
+  LMasterBindSource.Adapter := LMasterAdapter;
+  LMasterBindSource.Active := True;
+  FGridBindSources.Add(LMasterBindSource);
+  LMasterGridLink := TLinkGridToDataSource.Create(nil);
+  LMasterGridLink.DataSource := LMasterBindSource;
+  LMasterGridLink.GridControl := LMasterGrid;
+  LMasterGridLink.Active := True;
+  FGridLinks.Add(LMasterGridLink);
+  LDetailBindSource := TAdapterBindSource.Create(nil);
+  LDetailBindSource.Adapter := LDetailAdapter;
+  LDetailBindSource.Active := True;
+  FGridBindSources.Add(LDetailBindSource);
+  LDetailGridLink := TLinkGridToDataSource.Create(nil);
+  LDetailGridLink.DataSource := LDetailBindSource;
+  LDetailGridLink.GridControl := LDetailGrid;
+  LDetailGridLink.Active := True;
+  FGridLinks.Add(LDetailGridLink);
+  LSubdetailBindSource := TAdapterBindSource.Create(nil);
+  LSubdetailBindSource.Adapter := LSubdetailAdapter;
+  LSubdetailBindSource.Active := True;
+  FGridBindSources.Add(LSubdetailBindSource);
+  LSubdetailGridLink := TLinkGridToDataSource.Create(nil);
+  LSubdetailGridLink.DataSource := LSubdetailBindSource;
+  LSubdetailGridLink.GridControl := LSubdetailGrid;
+  LSubdetailGridLink.Active := True;
+  FGridLinks.Add(LSubdetailGridLink);
 end;
 
 {$ENDIF DCC}

--- a/Source/Livebindings/Janus.Controls.Helpers.pas
+++ b/Source/Livebindings/Janus.Controls.Helpers.pas
@@ -23,6 +23,8 @@
 
 unit Janus.Controls.Helpers;
 
+{$MESSAGE WARN 'Janus.Controls.Helpers: TListControls global dictionary is deprecated. Use TJanusBinder with FindComponent resolver instead. Will be removed in R22.6.'}
+
 interface
 
 uses

--- a/Source/Livebindings/Janus.FMX.Controls.pas
+++ b/Source/Livebindings/Janus.FMX.Controls.pas
@@ -23,6 +23,8 @@
 
 unit Janus.FMX.Controls;
 
+{$MESSAGE WARN 'Janus.FMX.Controls (shadowing technique) is deprecated. Use TJanusBinder instead. This unit will be removed in R22.6.'}
+
 interface
 
 uses

--- a/Source/Livebindings/Janus.LiveBindings.pas
+++ b/Source/Livebindings/Janus.LiveBindings.pas
@@ -35,7 +35,11 @@ uses
   Bindings.Helper,
   Data.Bind.ObjectScope,
   Generics.Collections,
-  Janus.Controls.Helpers;
+  Janus.Controls.Helpers
+  {$IFDEF DCC}
+  ,Janus.Binder.Resolver
+  {$ENDIF}
+  ;
 
 type
   LiveBindingsControl = class(TCustomAttribute)
@@ -71,6 +75,7 @@ type
 
   TJanusLivebindings = class
   private
+    FOwner: TComponent;
     FBindingExpressions: TObjectList<TBindingExpression>;
     procedure _GenerateLiveBindingsControls(const AAttribute: TCustomAttribute;
       const AProperty: TRttiProperty);
@@ -79,7 +84,8 @@ type
     procedure _GenerateLiveBindingsGridDetail(
       const AAttribute: TCustomAttribute; const AProperty: TRttiProperty);
   public
-    constructor Create; virtual;
+    constructor Create; overload; virtual;
+    constructor Create(const AOwner: TComponent); overload;
     destructor Destroy; override;
   end;
 
@@ -87,6 +93,12 @@ implementation
 
 uses
   Vcl.ComCtrls, Vcl.Grids;
+
+constructor TJanusLiveBindings.Create(const AOwner: TComponent);
+begin
+  FOwner := AOwner;
+  Create;
+end;
 
 constructor TJanusLiveBindings.Create;
 var
@@ -129,8 +141,14 @@ var
   LBindingExpressionComponent: TBindingExpression;
 begin
   LLiveBindingsControl := LiveBindingsControl(AAttribute);
-  // Get Component
-  LControl := TListControls.ListComponents.Items[LLiveBindingsControl.LinkControl] as TControl;
+  // Resolve via FindComponent first; fallback to global dictionary
+  LControl := nil;
+  {$IFDEF DCC}
+  if FOwner <> nil then
+    LControl := TJanusBinderResolver.Resolve(FOwner, LLiveBindingsControl.LinkControl) as TControl;
+  {$ENDIF}
+  if LControl = nil then
+    LControl := TListControls.ListComponents.Items[LLiveBindingsControl.LinkControl] as TControl;
   if LControl = nil then
     raise Exception.Create('Component [' + LLiveBindingsControl.LinkControl + '] not found!');
   // Expression do atributo

--- a/Source/Livebindings/Janus.VCL.Controls.pas
+++ b/Source/Livebindings/Janus.VCL.Controls.pas
@@ -23,6 +23,8 @@
 
 unit Janus.VCL.Controls;
 
+{$MESSAGE WARN 'Janus.VCL.Controls (shadowing technique) is deprecated. Use TJanusBinder instead. This unit will be removed in R22.6.'}
+
 interface
 
 uses

--- a/Source/RESTful/Server/Janus.Server.Resource.pas
+++ b/Source/RESTful/Server/Janus.Server.Resource.pas
@@ -1,11 +1,11 @@
 {
-      ORM Brasil � um ORM simples e descomplicado para quem utiliza Delphi
+      ORM Brasil é um ORM simples e descomplicado para quem utiliza Delphi
 
                    Copyright (c) 2018, Isaque Pinheiro
                           All rights reserved.
 }
 
-{ 
+{
   @abstract(REST Componentes)
   @created(20 Jun 2018)
   @author(Isaque Pinheiro <isaquepsp@gmail.com>)
@@ -32,7 +32,6 @@ uses
   MetaDbDiff.mapping.explorer,
   MetaDbDiff.mapping.popular,
   MetaDbDiff.mapping.register,
-  Janus.Json,
   Janus.Server.RestQuery.Parse,
   Janus.Server.RestObjectSet,
   DataEngine.FactoryInterfaces;
@@ -41,37 +40,37 @@ type
   TAppResourceBase = class
   private
     FConnection: IDBConnection;
-    const cRESOURCENOTFOUND = '{"exception":"Resource T%s not found!"}';
-    const cRESOURCENOTREGISTER = '{"exception":"Resource [%s] not registered on the server!"}';
-    const cRESOURCEPERMITION = '{"exception":"Resource [%s] without access permission by the [NotServerUse] attribute!"}';
-    const cRESOURCEREADONLY = '{"exception":"Resource %s is read-only (RESTReadOnly)"}';
-    const cRESOURCEVERBNOTALLOWED = '{"exception":"HTTP %s not allowed for %s"}';
-    const cEXCEPTIONJSON = '{"exception":"There was an error in trying to convert JSON into the class [%s]!"}';
-    const cRESOURCEDELETE = '{"result":"Resource %s delete command executed successfully"}';
-    const cRESOURCEINSERT = '{"result":"Resource %s insert command executed successfully", "params":[{%s}]}';
-    const cRESOURCEUPDATE = '{"result":"Resource %s update command executed successfully"}';
-
+    const
+      cRESOURCENOTFOUND    = '{"exception":"Resource T%s not found!"}';
+      cRESOURCENOTREGISTER = '{"exception":"Resource [%s] not registered on the server!"}';
+      cRESOURCEPERMITION   = '{"exception":"Resource [%s] without access permission by the [NotServerUse] attribute!"}';
+      cRESOURCEREADONLY    = '{"exception":"Resource %s is read-only (RESTReadOnly)"}';
+      cRESOURCEVERBNOTALLOWED = '{"exception":"HTTP %s not allowed for %s"}';
+      cEXCEPTIONJSON       = '{"exception":"There was an error in trying to convert JSON into the class [%s]!"}';
+      cRESOURCEDELETE      = '{"result":"Resource %s delete command executed successfully"}';
+      cRESOURCEINSERT      = '{"result":"Resource %s insert command executed successfully", "params":[{%s}]}';
+      cRESOURCEUPDATE      = '{"result":"Resource %s update command executed successfully"}';
     function ResolverFindToSkip(const AObjectSet: TRESTObjectSet;
-      const AQuery: TRESTQueryParse): String;
+      const AQuery: TRESTQueryParse): string;
     function ResolverFindFilter(const AObjectSet: TRESTObjectSet;
-      const AQuery: TRESTQueryParse): String;
+      const AQuery: TRESTQueryParse): string;
     function ResolverFindID(const AObjectSet: TRESTObjectSet;
-      const AQuery: TRESTQueryParse): String;
+      const AQuery: TRESTQueryParse): string;
     function ResolverFindAll(const AObjectSet: TRESTObjectSet;
-      const AQuery: TRESTQueryParse): String;
+      const AQuery: TRESTQueryParse): string;
   protected
     FResultCount: Integer;
-    function ParseInsert(const AQuery: TRESTQueryParse; const AValue: String): String;
-    function ParseUpdate(const AQuery: TRESTQueryParse; const AValue: String): String;
+    function ParseInsert(const AQuery: TRESTQueryParse; const AValue: string): string;
+    function ParseUpdate(const AQuery: TRESTQueryParse; const AValue: string): string;
   public
     constructor Create(const AConnection: IDBConnection); overload; virtual;
     destructor Destroy; override;
-    function ParseFind(const AQuery: TRESTQueryParse): String;
-    function ParseDelete(const AQuery: TRESTQueryParse): String;
-    function select(const AResource: String): String; overload; virtual;
-    function insert(const AResource: String; const AValue: String): String; overload; virtual;
-    function update(const AResource: String; const AValue: String): String; overload; virtual;
-    function delete(const AResource: String): String; overload; virtual;
+    function ParseFind(const AQuery: TRESTQueryParse): string;
+    function ParseDelete(const AQuery: TRESTQueryParse): string;
+    function select(const AResource: string): string; overload; virtual;
+    function insert(const AResource: string; const AValue: string): string; overload; virtual;
+    function update(const AResource: string; const AValue: string): string; overload; virtual;
+    function delete(const AResource: string): string; overload; virtual;
     function ResultCount: Integer;
   end;
 
@@ -81,8 +80,10 @@ uses
   MetaDbDiff.mapping.classes,
   MetaDbDiff.mapping.attributes,
   MetaDbDiff.rtti.helper,
+  Janus.Json,
   Janus.Objects.Helper,
-  Janus.Core.Consts;
+  Janus.Core.Consts,
+  Janus.Server.RestView.Manager;
 
 { TAppResourceBase }
 
@@ -92,7 +93,7 @@ begin
   FConnection := AConnection;
 end;
 
-function TAppResourceBase.delete(const AResource: String): String;
+function TAppResourceBase.delete(const AResource: string): string;
 begin
   Result := AResource;
 end;
@@ -103,7 +104,7 @@ begin
   inherited;
 end;
 
-function TAppResourceBase.insert(const AResource, AValue: String): String;
+function TAppResourceBase.insert(const AResource, AValue: string): string;
 var
   LQuery: TRESTQueryParse;
 begin
@@ -119,7 +120,7 @@ begin
   end;
 end;
 
-function TAppResourceBase.update(const AResource, AValue: String): String;
+function TAppResourceBase.update(const AResource, AValue: string): string;
 var
   LQuery: TRESTQueryParse;
 begin
@@ -135,7 +136,7 @@ begin
   end;
 end;
 
-function TAppResourceBase.ParseDelete(const AQuery: TRESTQueryParse): String;
+function TAppResourceBase.ParseDelete(const AQuery: TRESTQueryParse): string;
 var
   LObject: TObject;
   LClassType: TClass;
@@ -173,6 +174,9 @@ begin
   if TMappingExplorer.GetRESTReadOnly(LClassType) then
     raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
 
+  if TMappingExplorer.GetMappingView(LClassType) <> nil then
+    raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
   LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
   if LAllowVerbs.HasAllowList then
     if not (rvDELETE in LAllowVerbs.AllowedVerbs) then
@@ -185,10 +189,10 @@ begin
       FilterExecuteFind;
       // Busca o registro pelo ID
       IDExecuteFind;
-      // Caso nenhum dos dois m�todos encontre um registro, � gerado uma
-      // exce��o com uma mensagem de registro n�o encontrado para quem requisitou
+      // Caso nenhum dos dois métodos encontre um registro, é gerado uma
+      // exceção com uma mensagem de registro não encontrado para quem requisitou
       ExceptionExecute;
-      // Se passar tudo ok, ser� executado o m�todo do Janus
+      // Se passar tudo ok, será executado o método do Janus
       LObjectSet.Delete(LObject);
       Result := Format(cRESOURCEDELETE, [AQuery.ResourceName]);
     finally
@@ -204,7 +208,7 @@ begin
   end;
 end;
 
-function TAppResourceBase.ParseFind(const AQuery: TRESTQueryParse): String;
+function TAppResourceBase.ParseFind(const AQuery: TRESTQueryParse): string;
 var
   LClassType: TClass;
   LObjectSet: TRESTObjectSet;
@@ -227,6 +231,9 @@ begin
       if not (rvGET in LAllowVerbs.AllowedVerbs) then
         raise Exception.CreateFmt(cRESOURCEVERBNOTALLOWED, ['GET', AQuery.ResourceName]);
 
+  if TMappingExplorer.GetMappingView(LClassType) <> nil then
+    TRESTViewManager.EnsureViewLazy(LClassType, FConnection);
+
   LObjectSet := TRESTObjectSet.Create(FConnection, LClassType);
   try
     if AQuery.Top > 0 then
@@ -245,14 +252,14 @@ begin
 end;
 
 function TAppResourceBase.ParseInsert(const AQuery: TRESTQueryParse;
-  const AValue: String): String;
+  const AValue: string): string;
 var
   LPrimaryKey: TPrimaryKeyColumnsMapping;
   LColumn: TColumnMapping;
   LObject: TObject;
   LClassType: TClass;
   LObjectSet: TRESTObjectSet;
-  LValues: String;
+  LValues: string;
   LAllowVerbs: TRESTAllowVerbCache;
 begin
   LClassType := TMappingExplorer.GetRepositoryMapping
@@ -261,6 +268,9 @@ begin
     raise Exception.CreateFmt(cRESOURCENOTREGISTER, [AQuery.ResourceName]);
 
   if TMappingExplorer.GetRESTReadOnly(LClassType) then
+    raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
+  if TMappingExplorer.GetMappingView(LClassType) <> nil then
     raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
 
   LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
@@ -305,7 +315,7 @@ begin
 end;
 
 function TAppResourceBase.ParseUpdate(const AQuery: TRESTQueryParse;
-  const AValue: String): String;
+  const AValue: string): string;
 var
   LObjectOld: TObject;
   LObjectNew: TObject;
@@ -313,7 +323,7 @@ var
   LObjectSet: TRESTObjectSet;
   LPrimaryKey: TPrimaryKeyColumnsMapping;
   LColumn: TColumnMapping;
-  LWhere: String;
+  LWhere: string;
   LAllowVerbs: TRESTAllowVerbCache;
 begin
   LClassType := TMappingExplorer.GetRepositoryMapping
@@ -322,6 +332,9 @@ begin
     Exit;
 
   if TMappingExplorer.GetRESTReadOnly(LClassType) then
+    raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
+
+  if TMappingExplorer.GetMappingView(LClassType) <> nil then
     raise Exception.CreateFmt(cRESOURCEREADONLY, [AQuery.ResourceName]);
 
   LAllowVerbs := TMappingExplorer.GetRESTAllowVerbs(LClassType);
@@ -373,7 +386,7 @@ begin
 end;
 
 function TAppResourceBase.ResolverFindAll(const AObjectSet: TRESTObjectSet;
-  const AQuery: TRESTQueryParse): String;
+  const AQuery: TRESTQueryParse): string;
 var
   LObjectList: TObjectList<TObject>;
 begin
@@ -390,7 +403,7 @@ begin
 end;
 
 function TAppResourceBase.ResolverFindFilter(const AObjectSet: TRESTObjectSet;
-  const AQuery: TRESTQueryParse): String;
+  const AQuery: TRESTQueryParse): string;
 var
   LObjectList: TObjectList<TObject>;
 begin
@@ -407,7 +420,7 @@ begin
 end;
 
 function TAppResourceBase.ResolverFindID(const AObjectSet: TRESTObjectSet;
-  const AQuery: TRESTQueryParse): String;
+  const AQuery: TRESTQueryParse): string;
 var
   LObject: TObject;
 begin
@@ -423,7 +436,7 @@ begin
 end;
 
 function TAppResourceBase.ResolverFindToSkip(const AObjectSet: TRESTObjectSet;
-  const AQuery: TRESTQueryParse): String;
+  const AQuery: TRESTQueryParse): string;
 var
   LObjectList: TObjectList<TObject>;
 begin
@@ -447,7 +460,7 @@ begin
   Result := FResultCount;
 end;
 
-function TAppResourceBase.select(const AResource: String): String;
+function TAppResourceBase.select(const AResource: string): string;
 begin
   Result := AResource;
 end;

--- a/Source/RESTful/Server/Janus.Server.RestView.Manager.pas
+++ b/Source/RESTful/Server/Janus.Server.RestView.Manager.pas
@@ -22,6 +22,7 @@ interface
 
 uses
   SysUtils,
+  Generics.Collections,
   DataEngine.FactoryInterfaces,
   MetaDbDiff.Mapping.Explorer,
   FluentSQL,
@@ -29,19 +30,24 @@ uses
   FluentSQL.Interfaces;
 
 type
+  ERegistryMissingException = class(Exception);
+
   TRESTViewManager = class
   private
-    class function _GetViewName(const AClassType: TClass): String;
+    class var FViewDefinitionRegistry: TDictionary<string, TFunc<IFluentSQL>>;
+    class var FViewEnsuredCache: TDictionary<string, Boolean>;
+    class function _GetViewName(const AClassType: TClass): string;
     class function _MapDriverToFluent(const ADriver: TDBEngineDriver): TFluentSQLDriver;
     class function _SupportsCreateOrReplace(const ADriver: TDBEngineDriver): Boolean;
-    class procedure _ExecuteDDL(const ASQL: String; const AConnection: IDBConnection);
+    class procedure _ExecuteDDL(const ASQL: string; const AConnection: IDBConnection);
   public
-    // Creates or replaces the VIEW in the database for the given mapped class.
-    // AClassType must be decorated with [View] and [Table('view_name','')].
-    // ASelect is the IFluentSQL query that defines the view body.
-    // Call only at application startup/setup — never inside a REST handler.
     class procedure EnsureView(const AClassType: TClass; const ASelect: IFluentSQL;
       const AConnection: IDBConnection);
+    class procedure Register(const AClassType: TClass;
+      const ASelectFactory: TFunc<IFluentSQL>);
+    class procedure EnsureViewLazy(const AClassType: TClass;
+      const AConnection: IDBConnection);
+    class procedure ClearCache;
   end;
 
 implementation
@@ -51,7 +57,7 @@ uses
 
 { TRESTViewManager }
 
-class function TRESTViewManager._GetViewName(const AClassType: TClass): String;
+class function TRESTViewManager._GetViewName(const AClassType: TClass): string;
 var
   LTableMapping: TTableMapping;
   LViewMapping: TViewMapping;
@@ -90,7 +96,7 @@ begin
   Result := ADriver in [dnMySQL, dnMariaDB, dnPostgreSQL, dnOracle];
 end;
 
-class procedure TRESTViewManager._ExecuteDDL(const ASQL: String;
+class procedure TRESTViewManager._ExecuteDDL(const ASQL: string;
   const AConnection: IDBConnection);
 begin
   if ASQL = '' then
@@ -101,11 +107,11 @@ end;
 class procedure TRESTViewManager.EnsureView(const AClassType: TClass;
   const ASelect: IFluentSQL; const AConnection: IDBConnection);
 var
-  LViewName: String;
+  LViewName: string;
   LDriver: TDBEngineDriver;
   LDialect: TFluentSQLDriver;
-  LCreateSQL: String;
-  LDropSQL: String;
+  LCreateSQL: string;
+  LDropSQL: string;
   LSchema: IFluentSchema;
 begin
   if not Assigned(AClassType) then
@@ -138,6 +144,49 @@ begin
     _ExecuteDDL(LDropSQL, AConnection);
     _ExecuteDDL(LCreateSQL, AConnection);
   end;
+  FViewEnsuredCache.AddOrSetValue(AClassType.ClassName, True);
 end;
+
+class procedure TRESTViewManager.Register(const AClassType: TClass;
+  const ASelectFactory: TFunc<IFluentSQL>);
+begin
+  if not Assigned(AClassType) then
+    raise EArgumentNilException.Create('AClassType must not be nil');
+  if not Assigned(ASelectFactory) then
+    raise EArgumentNilException.Create('ASelectFactory must not be nil');
+  FViewDefinitionRegistry.AddOrSetValue(AClassType.ClassName, ASelectFactory);
+end;
+
+class procedure TRESTViewManager.EnsureViewLazy(const AClassType: TClass;
+  const AConnection: IDBConnection);
+var
+  LFactory: TFunc<IFluentSQL>;
+  LSelect: IFluentSQL;
+begin
+  if FViewEnsuredCache.ContainsKey(AClassType.ClassName) then
+    Exit;
+  if not FViewDefinitionRegistry.TryGetValue(AClassType.ClassName, LFactory) then
+    raise ERegistryMissingException.CreateFmt(
+      'No view definition registered for class %s. ' +
+      'Call TRESTViewManager.Register before the server handles GET requests.',
+      [AClassType.ClassName]);
+  LSelect := LFactory;
+  EnsureView(AClassType, LSelect, AConnection);
+end;
+
+class procedure TRESTViewManager.ClearCache;
+begin
+  FViewEnsuredCache.Clear;
+end;
+
+initialization
+  TRESTViewManager.FViewDefinitionRegistry :=
+    TDictionary<string, TFunc<IFluentSQL>>.Create;
+  TRESTViewManager.FViewEnsuredCache :=
+    TDictionary<string, Boolean>.Create;
+
+finalization
+  FreeAndNil(TRESTViewManager.FViewDefinitionRegistry);
+  FreeAndNil(TRESTViewManager.FViewEnsuredCache);
 
 end.

--- a/Test/Delphi/JanusLiveBindings.dpr
+++ b/Test/Delphi/JanusLiveBindings.dpr
@@ -16,7 +16,9 @@ uses
   DUnitX.Loggers.Console,
   DUnitX.Loggers.Xml.NUnit,
   /// LiveBindings Tests — ESP-004 / R22.1
-  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas';
+  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas',
+  /// LiveBindings Tests — ESP-004 / R22.2
+  Tests.Janus.LiveBindings.R222 in 'Tests\Tests.Janus.LiveBindings.R222.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/JanusLiveBindings.dpr
+++ b/Test/Delphi/JanusLiveBindings.dpr
@@ -1,0 +1,107 @@
+program JanusLiveBindings;
+
+{$IFNDEF TESTINSIGHT}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+{$STRONGLINKTYPES ON}
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.IOUtils,
+  {$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX,
+  {$ENDIF}
+  DUnitX.TestFramework,
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  /// LiveBindings Tests — ESP-004 / R22.1
+  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas';
+
+const
+  EXIT_SUCCESS = 0;
+  EXIT_FAILURE = 1;
+
+var
+  LRunner: ITestRunner;
+  LResults: IRunResults;
+  LLogger: ITestLogger;
+  LNunitLogger: ITestLogger;
+  LXmlOutputFile: string;
+  LXmlDir: string;
+  LProbeFile: string;
+  LProbeStream: TFileStream;
+  LRunStartTime: TDateTime;
+begin
+{$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX.RunRegisteredTests;
+  Exit;
+{$ENDIF}
+  System.ExitCode := EXIT_FAILURE;
+  try
+    LRunStartTime := Now;
+    TDUnitX.CheckCommandLine;
+    LXmlOutputFile := TDUnitX.Options.XMLOutputFile;
+    if LXmlOutputFile <> '' then
+    begin
+      LXmlOutputFile := TPath.GetFullPath(LXmlOutputFile);
+      LXmlDir := TPath.GetDirectoryName(LXmlOutputFile);
+      if (LXmlDir <> '') and (not TDirectory.Exists(LXmlDir)) then
+        TDirectory.CreateDirectory(LXmlDir);
+      if LXmlDir <> '' then
+      begin
+        LProbeFile := TPath.Combine(LXmlDir, '.janus_livebindings_write_probe.tmp');
+        LProbeStream := nil;
+        try
+          LProbeStream := TFileStream.Create(LProbeFile, fmCreate);
+        finally
+          FreeAndNil(LProbeStream);
+          if TFile.Exists(LProbeFile) then
+            TFile.Delete(LProbeFile);
+        end;
+      end;
+    end;
+    LRunner := TDUnitX.CreateRunner;
+    LLogger := TDUnitXConsoleLogger.Create(True);
+    LRunner.AddLogger(LLogger);
+    if LXmlOutputFile <> '' then
+      LNunitLogger := TDUnitXXMLNUnitFileLogger.Create(LXmlOutputFile)
+    else
+      LNunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    LRunner.AddLogger(LNunitLogger);
+    LRunner.FailsOnNoAsserts := False;
+    LResults := LRunner.Execute;
+    if LXmlOutputFile <> '' then
+    begin
+      if not TFile.Exists(LXmlOutputFile) then
+      begin
+        System.Writeln('EVIDENCE ERROR: XML artifact was not generated: ' + LXmlOutputFile);
+        System.ExitCode := EXIT_FAILURE;
+        Exit;
+      end;
+      if TFile.GetLastWriteTime(LXmlOutputFile) < LRunStartTime then
+      begin
+        System.Writeln('EVIDENCE ERROR: XML artifact is stale.');
+        System.ExitCode := EXIT_FAILURE;
+        Exit;
+      end;
+    end;
+    if not LResults.AllPassed then
+      System.ExitCode := EXIT_FAILURE
+    else
+      System.ExitCode := EXIT_SUCCESS;
+    {$IFNDEF CI}
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done.. press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+  except
+    on E: Exception do
+    begin
+      System.Writeln(E.ClassName, ': ', E.Message);
+      System.ExitCode := EXIT_FAILURE;
+    end;
+  end;
+end.

--- a/Test/Delphi/JanusLiveBindings.dpr
+++ b/Test/Delphi/JanusLiveBindings.dpr
@@ -18,7 +18,9 @@ uses
   /// LiveBindings Tests — ESP-004 / R22.1
   Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas',
   /// LiveBindings Tests — ESP-004 / R22.2
-  Tests.Janus.LiveBindings.R222 in 'Tests\Tests.Janus.LiveBindings.R222.pas';
+  Tests.Janus.LiveBindings.R222 in 'Tests\Tests.Janus.LiveBindings.R222.pas',
+  /// LiveBindings Tests — ESP-002 / R22.3
+  Tests.Janus.LiveBindings.R223 in 'Tests\Tests.Janus.LiveBindings.R223.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/JanusRESTHorseConsole.dpr
+++ b/Test/Delphi/JanusRESTHorseConsole.dpr
@@ -1,0 +1,332 @@
+program JanusRESTHorseConsole;
+
+{$APPTYPE CONSOLE}
+{$STRONGLINKTYPES ON}
+
+uses
+  System.SysUtils,
+  System.Classes,
+  System.IOUtils,
+  Net.HTTPClient,
+  Net.URLClient,
+  // FireDAC silent wait-cursor — required when TFDConnection is used from
+  // non-VCL threads. Registers a null GUI provider so FireDAC does not
+  // invoke VCL cursor callbacks that AV outside the main thread.
+  FireDAC.ConsoleUI.Wait,
+  FireDAC.Comp.Client,
+  FireDAC.Stan.Def,
+  FireDAC.Stan.Intf,
+  FireDAC.Stan.Pool,
+  FireDAC.Stan.Async,
+  FireDAC.UI.Intf,
+  FireDAC.Phys.Intf,
+  FireDAC.Phys.SQLite,
+  FireDAC.Phys.SQLiteDef,
+  // SQLite DML generator — registers the SQLite factory with TDriverRegister
+  Janus.DML.Generator.SQLite,
+  // DataEngine
+  DataEngine.FactoryInterfaces,
+  DataEngine.FactoryConnection,
+  DataEngine.FactoryFireDAC,
+  // Janus
+  MetaDbDiff.Mapping.Register,
+  Janus.Server.Horse,
+  // Horse
+  Horse,
+  Horse.Core.RouterTree,
+  // Console models
+  JanusRESTHorseConsole.Models in 'Tests\JanusRESTHorseConsole.Models.pas';
+
+const
+  cDB_PATH         = 'janus_rest_console_test.db';
+  cAPI_PREFIX      = 'api/Janus';
+  cTIMEOUT_MS      = 2000;
+  cVERBNOTALLOWED  = 'not allowed for';
+  cREADONLY_MSG    = 'read-only (RESTReadOnly)';
+  cSCENARIOS_TOTAL = 12;
+  EXIT_SUCCESS     = 0;
+  EXIT_FAILURE     = 1;
+
+var
+  GPort: Integer;
+  GPassCount: Integer;
+  GFailCount: Integer;
+
+procedure _Assert(const AScenario: String; const ACondition: Boolean;
+  const AReason: String = '');
+begin
+  if ACondition then
+  begin
+    Writeln('[PASS] ' + AScenario);
+    Inc(GPassCount);
+  end
+  else
+  begin
+    if AReason <> '' then
+      Writeln('[FAIL] ' + AScenario + ' -- ' + AReason)
+    else
+      Writeln('[FAIL] ' + AScenario);
+    Inc(GFailCount);
+  end;
+end;
+
+function _URL(const AResource: String): String;
+begin
+  Result := Format('http://127.0.0.1:%d/%s/%s', [GPort, cAPI_PREFIX, AResource]);
+end;
+
+function _Get(const AURL: String): String;
+var
+  LClient: THTTPClient;
+begin
+  LClient := THTTPClient.Create;
+  try
+    LClient.ConnectionTimeout := cTIMEOUT_MS;
+    LClient.ResponseTimeout := cTIMEOUT_MS;
+    Result := LClient.Get(AURL).ContentAsString(TEncoding.UTF8);
+  finally
+    LClient.Free;
+  end;
+end;
+
+function _Post(const AURL: String; const ABody: String): String;
+var
+  LClient: THTTPClient;
+  LStream: TStringStream;
+begin
+  LClient := THTTPClient.Create;
+  try
+    LClient.ConnectionTimeout := cTIMEOUT_MS;
+    LClient.ResponseTimeout := cTIMEOUT_MS;
+    LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+    try
+      Result := LClient.Post(AURL, LStream, nil,
+        [TNameValuePair.Create('Content-Type', 'application/json')])
+        .ContentAsString(TEncoding.UTF8);
+    finally
+      LStream.Free;
+    end;
+  finally
+    LClient.Free;
+  end;
+end;
+
+function _Put(const AURL: String; const ABody: String): String;
+var
+  LClient: THTTPClient;
+  LStream: TStringStream;
+begin
+  LClient := THTTPClient.Create;
+  try
+    LClient.ConnectionTimeout := cTIMEOUT_MS;
+    LClient.ResponseTimeout := cTIMEOUT_MS;
+    LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+    try
+      Result := LClient.Put(AURL, LStream, nil,
+        [TNameValuePair.Create('Content-Type', 'application/json')])
+        .ContentAsString(TEncoding.UTF8);
+    finally
+      LStream.Free;
+    end;
+  finally
+    LClient.Free;
+  end;
+end;
+
+function _Delete(const AURL: String): String;
+var
+  LClient: THTTPClient;
+begin
+  LClient := THTTPClient.Create;
+  try
+    LClient.ConnectionTimeout := cTIMEOUT_MS;
+    LClient.ResponseTimeout := cTIMEOUT_MS;
+    Result := LClient.Delete(AURL).ContentAsString(TEncoding.UTF8);
+  finally
+    LClient.Free;
+  end;
+end;
+
+procedure _CreateSchema(const AConn: IDBConnection);
+begin
+  AConn.ExecuteDirect('DROP TABLE IF EXISTS demo_product');
+  AConn.ExecuteDirect('DROP TABLE IF EXISTS demo_readonly');
+  AConn.ExecuteDirect('DROP TABLE IF EXISTS demo_get_only');
+  AConn.ExecuteDirect('DROP TABLE IF EXISTS demo_get_post');
+  AConn.ExecuteDirect(
+    'CREATE TABLE demo_product (' +
+    '  id    INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name  VARCHAR(100) NOT NULL,' +
+    '  price REAL DEFAULT 0)');
+  AConn.ExecuteDirect(
+    'CREATE TABLE demo_readonly (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL)');
+  AConn.ExecuteDirect(
+    'CREATE TABLE demo_get_only (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL)');
+  AConn.ExecuteDirect(
+    'CREATE TABLE demo_get_post (' +
+    '  id   INTEGER PRIMARY KEY AUTOINCREMENT,' +
+    '  name VARCHAR(100) NOT NULL)');
+  AConn.ExecuteDirect('INSERT INTO demo_readonly (name) VALUES (''ReadOnlySeed'')');
+  AConn.ExecuteDirect('INSERT INTO demo_get_only (name) VALUES (''GetOnlySeed'')');
+  AConn.ExecuteDirect('INSERT INTO demo_get_post (name) VALUES (''GetPostSeed'')');
+end;
+
+procedure _RegisterModels;
+begin
+  TRegisterClass.RegisterEntity(TDemoProduct);
+  TRegisterClass.RegisterEntity(TDemoReadOnly);
+  TRegisterClass.RegisterEntity(TDemoGetOnly);
+  TRegisterClass.RegisterEntity(TDemoGetPost);
+end;
+
+function _StartServer(const AHorseConn: IDBConnection): TRESTServerHorse;
+var
+  LThread: TThread;
+begin
+  Result := TRESTServerHorse.Create(nil, AHorseConn, cAPI_PREFIX);
+  LThread := TThread.CreateAnonymousThread(
+    procedure
+    begin
+      THorse.Listen(GPort);
+    end);
+  LThread.FreeOnTerminate := True;
+  LThread.Start;
+  Sleep(200);
+end;
+
+procedure _RunDemoProductScenarios;
+var
+  LResult: String;
+begin
+  LResult := _Get(_URL('DemoProduct'));
+  _Assert('GET DemoProduct list',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Post(_URL('DemoProduct'), '{"name":"TestProduct","price":9.99}');
+  _Assert('POST DemoProduct insert',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Put(_URL('DemoProduct'), '{"id":1,"name":"UpdatedProduct","price":19.99}');
+  _Assert('PUT DemoProduct update',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Delete(_URL('DemoProduct(1)'));
+  _Assert('DELETE DemoProduct',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+end;
+
+procedure _RunDemoReadOnlyScenarios;
+var
+  LResult: String;
+begin
+  LResult := _Get(_URL('DemoReadOnly'));
+  _Assert('GET DemoReadOnly (allowed)',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Post(_URL('DemoReadOnly'), '{"name":"ShouldFail"}');
+  _Assert('POST DemoReadOnly blocked (RESTReadOnly)', LResult.Contains(cREADONLY_MSG));
+  LResult := _Put(_URL('DemoReadOnly'), '{"id":1,"name":"ShouldFail"}');
+  _Assert('PUT DemoReadOnly blocked (RESTReadOnly)', LResult.Contains(cREADONLY_MSG));
+end;
+
+procedure _RunDemoGetOnlyScenarios;
+var
+  LResult: String;
+begin
+  LResult := _Get(_URL('DemoGetOnly'));
+  _Assert('GET DemoGetOnly (allowed)',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Post(_URL('DemoGetOnly'), '{"name":"ShouldFail"}');
+  _Assert('POST DemoGetOnly blocked (RESTAllowGET)', LResult.Contains(cVERBNOTALLOWED));
+end;
+
+procedure _RunDemoGetPostScenarios;
+var
+  LResult: String;
+begin
+  LResult := _Get(_URL('DemoGetPost'));
+  _Assert('GET DemoGetPost (allowed)',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Post(_URL('DemoGetPost'), '{"name":"GetPostInsert"}');
+  _Assert('POST DemoGetPost insert (allowed)',
+    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
+  LResult := _Delete(_URL('DemoGetPost(1)'));
+  _Assert('DELETE DemoGetPost blocked (RESTAllowGET+POST)', LResult.Contains(cVERBNOTALLOWED));
+end;
+
+procedure RunTests;
+begin
+  Writeln('=== JanusRESTHorseConsole Self-Test ===');
+  Writeln(Format('Server: http://127.0.0.1:%d/%s', [GPort, cAPI_PREFIX]));
+  Writeln('');
+  _RunDemoProductScenarios;
+  _RunDemoReadOnlyScenarios;
+  _RunDemoGetOnlyScenarios;
+  _RunDemoGetPostScenarios;
+  Writeln('');
+  Writeln(Format('Result: %d/%d passed', [GPassCount, cSCENARIOS_TOTAL]));
+end;
+
+var
+  LFDConn: TFDConnection;
+  LConnection: IDBConnection;
+  LHorseFDConn: TFDConnection;
+  LHorseConn: IDBConnection;
+  LServer: TRESTServerHorse;
+  LOldRoutes: THorseRouterTree;
+  LNewRoutes: THorseRouterTree;
+begin
+  IsMultiThread := True;
+  FDManager.SilentMode := True;
+  Randomize;
+  GPort := 9200 + Random(100);
+  GPassCount := 0;
+  GFailCount := 0;
+  System.ExitCode := EXIT_FAILURE;
+  try
+    LFDConn := TFDConnection.Create(nil);
+    LFDConn.Params.DriverID := 'SQLite';
+    LFDConn.Params.Database := cDB_PATH;
+    LFDConn.Params.Values['OpenMode'] := 'CreateUTF8';
+    LFDConn.Connected := True;
+    LConnection := TFactoryFireDAC.Create(LFDConn, dnSQLite);
+    LHorseFDConn := TFDConnection.Create(nil);
+    LHorseFDConn.Params.DriverID := 'SQLite';
+    LHorseFDConn.Params.Database := cDB_PATH;
+    LHorseFDConn.Params.Values['OpenMode'] := 'CreateUTF8';
+    LHorseFDConn.ResourceOptions.SilentMode := True;
+    LHorseFDConn.Connected := True;
+    LHorseConn := TFactoryFireDAC.Create(LHorseFDConn, dnSQLite);
+    _CreateSchema(LConnection);
+    _RegisterModels;
+    LServer := _StartServer(LHorseConn);
+    try
+      RunTests;
+      if GFailCount = 0 then
+        System.ExitCode := EXIT_SUCCESS;
+      Writeln('Server still running — press ENTER to exit');
+      Readln;
+    finally
+      THorse.StopListen;
+      LOldRoutes := THorse.Routes;
+      LNewRoutes := THorseRouterTree.Create;
+      THorse.Routes := LNewRoutes;
+      LOldRoutes.Free;
+      FreeAndNil(LServer);
+    end;
+    LHorseConn := nil;
+    LHorseFDConn.Connected := False;
+    FreeAndNil(LHorseFDConn);
+    LConnection := nil;
+    LFDConn.Connected := False;
+    FreeAndNil(LFDConn);
+  except
+    on E: Exception do
+    begin
+      Writeln(E.ClassName + ': ' + E.Message);
+      System.ExitCode := EXIT_FAILURE;
+    end;
+  end;
+  if TFile.Exists(cDB_PATH) then
+    TFile.Delete(cDB_PATH);
+end.

--- a/Test/Delphi/JanusRESTHorseConsole.dpr
+++ b/Test/Delphi/JanusRESTHorseConsole.dpr
@@ -7,11 +7,6 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
-  Net.HTTPClient,
-  Net.URLClient,
-  // FireDAC silent wait-cursor — required when TFDConnection is used from
-  // non-VCL threads. Registers a null GUI provider so FireDAC does not
-  // invoke VCL cursor callbacks that AV outside the main thread.
   FireDAC.ConsoleUI.Wait,
   FireDAC.Comp.Client,
   FireDAC.Stan.Def,
@@ -22,130 +17,24 @@ uses
   FireDAC.Phys.Intf,
   FireDAC.Phys.SQLite,
   FireDAC.Phys.SQLiteDef,
-  // SQLite DML generator — registers the SQLite factory with TDriverRegister
   Janus.DML.Generator.SQLite,
-  // DataEngine
   DataEngine.FactoryInterfaces,
   DataEngine.FactoryConnection,
   DataEngine.FactoryFireDAC,
-  // Janus
   MetaDbDiff.Mapping.Register,
-  Janus.Server.Horse,
-  // Horse
   Horse,
   Horse.Core.RouterTree,
-  // Console models
-  JanusRESTHorseConsole.Models in 'Tests\JanusRESTHorseConsole.Models.pas';
+  JanusRESTHorseConsole.Interfaces in 'Tests\JanusRESTHorseConsole.Interfaces.pas',
+  JanusRESTHorseConsole.DataModule  in 'Tests\JanusRESTHorseConsole.DataModule.pas',
+  JanusRESTHorseConsole.Provider    in 'Tests\JanusRESTHorseConsole.Provider.pas',
+  JanusRESTHorseConsole.Models      in 'Tests\JanusRESTHorseConsole.Models.pas';
 
 const
-  cDB_PATH         = 'janus_rest_console_test.db';
-  cAPI_PREFIX      = 'api/Janus';
-  cTIMEOUT_MS      = 2000;
-  cVERBNOTALLOWED  = 'not allowed for';
-  cREADONLY_MSG    = 'read-only (RESTReadOnly)';
-  cSCENARIOS_TOTAL = 12;
-  EXIT_SUCCESS     = 0;
-  EXIT_FAILURE     = 1;
+  cDB_PATH    = 'janus_rest_console_test.db';
+  cAPI_PREFIX = 'api/Janus';
 
 var
   GPort: Integer;
-  GPassCount: Integer;
-  GFailCount: Integer;
-
-procedure _Assert(const AScenario: String; const ACondition: Boolean;
-  const AReason: String = '');
-begin
-  if ACondition then
-  begin
-    Writeln('[PASS] ' + AScenario);
-    Inc(GPassCount);
-  end
-  else
-  begin
-    if AReason <> '' then
-      Writeln('[FAIL] ' + AScenario + ' -- ' + AReason)
-    else
-      Writeln('[FAIL] ' + AScenario);
-    Inc(GFailCount);
-  end;
-end;
-
-function _URL(const AResource: String): String;
-begin
-  Result := Format('http://127.0.0.1:%d/%s/%s', [GPort, cAPI_PREFIX, AResource]);
-end;
-
-function _Get(const AURL: String): String;
-var
-  LClient: THTTPClient;
-begin
-  LClient := THTTPClient.Create;
-  try
-    LClient.ConnectionTimeout := cTIMEOUT_MS;
-    LClient.ResponseTimeout := cTIMEOUT_MS;
-    Result := LClient.Get(AURL).ContentAsString(TEncoding.UTF8);
-  finally
-    LClient.Free;
-  end;
-end;
-
-function _Post(const AURL: String; const ABody: String): String;
-var
-  LClient: THTTPClient;
-  LStream: TStringStream;
-begin
-  LClient := THTTPClient.Create;
-  try
-    LClient.ConnectionTimeout := cTIMEOUT_MS;
-    LClient.ResponseTimeout := cTIMEOUT_MS;
-    LStream := TStringStream.Create(ABody, TEncoding.UTF8);
-    try
-      Result := LClient.Post(AURL, LStream, nil,
-        [TNameValuePair.Create('Content-Type', 'application/json')])
-        .ContentAsString(TEncoding.UTF8);
-    finally
-      LStream.Free;
-    end;
-  finally
-    LClient.Free;
-  end;
-end;
-
-function _Put(const AURL: String; const ABody: String): String;
-var
-  LClient: THTTPClient;
-  LStream: TStringStream;
-begin
-  LClient := THTTPClient.Create;
-  try
-    LClient.ConnectionTimeout := cTIMEOUT_MS;
-    LClient.ResponseTimeout := cTIMEOUT_MS;
-    LStream := TStringStream.Create(ABody, TEncoding.UTF8);
-    try
-      Result := LClient.Put(AURL, LStream, nil,
-        [TNameValuePair.Create('Content-Type', 'application/json')])
-        .ContentAsString(TEncoding.UTF8);
-    finally
-      LStream.Free;
-    end;
-  finally
-    LClient.Free;
-  end;
-end;
-
-function _Delete(const AURL: String): String;
-var
-  LClient: THTTPClient;
-begin
-  LClient := THTTPClient.Create;
-  try
-    LClient.ConnectionTimeout := cTIMEOUT_MS;
-    LClient.ResponseTimeout := cTIMEOUT_MS;
-    Result := LClient.Delete(AURL).ContentAsString(TEncoding.UTF8);
-  finally
-    LClient.Free;
-  end;
-end;
 
 procedure _CreateSchema(const AConn: IDBConnection);
 begin
@@ -183,11 +72,33 @@ begin
   TRegisterClass.RegisterEntity(TDemoGetPost);
 end;
 
-function _StartServer(const AHorseConn: IDBConnection): TRESTServerHorse;
 var
+  LFDConn: TFDConnection;
+  LConnection: IDBConnection;
+  LProvider: IProvider;
   LThread: TThread;
+  LOldRoutes: THorseRouterTree;
+  LNewRoutes: THorseRouterTree;
 begin
-  Result := TRESTServerHorse.Create(nil, AHorseConn, cAPI_PREFIX);
+  IsMultiThread := True;
+  FDManager.SilentMode := True;
+  Randomize;
+  GPort := 9200 + Random(100);
+  LFDConn := TFDConnection.Create(nil);
+  try
+    LFDConn.Params.DriverID := 'SQLite';
+    LFDConn.Params.Database := cDB_PATH;
+    LFDConn.Params.Values['OpenMode'] := 'CreateUTF8';
+    LFDConn.Connected := True;
+    LConnection := TFactoryFireDAC.Create(LFDConn, dnSQLite);
+    _CreateSchema(LConnection);
+    LConnection := nil;
+    LFDConn.Connected := False;
+  finally
+    FreeAndNil(LFDConn);
+  end;
+  _RegisterModels;
+  LProvider := TProviderJanus.Create;
   LThread := TThread.CreateAnonymousThread(
     procedure
     begin
@@ -196,137 +107,16 @@ begin
   LThread.FreeOnTerminate := True;
   LThread.Start;
   Sleep(200);
-end;
-
-procedure _RunDemoProductScenarios;
-var
-  LResult: String;
-begin
-  LResult := _Get(_URL('DemoProduct'));
-  _Assert('GET DemoProduct list',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Post(_URL('DemoProduct'), '{"name":"TestProduct","price":9.99}');
-  _Assert('POST DemoProduct insert',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Put(_URL('DemoProduct'), '{"id":1,"name":"UpdatedProduct","price":19.99}');
-  _Assert('PUT DemoProduct update',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Delete(_URL('DemoProduct(1)'));
-  _Assert('DELETE DemoProduct',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-end;
-
-procedure _RunDemoReadOnlyScenarios;
-var
-  LResult: String;
-begin
-  LResult := _Get(_URL('DemoReadOnly'));
-  _Assert('GET DemoReadOnly (allowed)',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Post(_URL('DemoReadOnly'), '{"name":"ShouldFail"}');
-  _Assert('POST DemoReadOnly blocked (RESTReadOnly)', LResult.Contains(cREADONLY_MSG));
-  LResult := _Put(_URL('DemoReadOnly'), '{"id":1,"name":"ShouldFail"}');
-  _Assert('PUT DemoReadOnly blocked (RESTReadOnly)', LResult.Contains(cREADONLY_MSG));
-end;
-
-procedure _RunDemoGetOnlyScenarios;
-var
-  LResult: String;
-begin
-  LResult := _Get(_URL('DemoGetOnly'));
-  _Assert('GET DemoGetOnly (allowed)',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Post(_URL('DemoGetOnly'), '{"name":"ShouldFail"}');
-  _Assert('POST DemoGetOnly blocked (RESTAllowGET)', LResult.Contains(cVERBNOTALLOWED));
-end;
-
-procedure _RunDemoGetPostScenarios;
-var
-  LResult: String;
-begin
-  LResult := _Get(_URL('DemoGetPost'));
-  _Assert('GET DemoGetPost (allowed)',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Post(_URL('DemoGetPost'), '{"name":"GetPostInsert"}');
-  _Assert('POST DemoGetPost insert (allowed)',
-    not LResult.Contains(cVERBNOTALLOWED) and not LResult.Contains(cREADONLY_MSG));
-  LResult := _Delete(_URL('DemoGetPost(1)'));
-  _Assert('DELETE DemoGetPost blocked (RESTAllowGET+POST)', LResult.Contains(cVERBNOTALLOWED));
-end;
-
-procedure RunTests;
-begin
-  Writeln('=== JanusRESTHorseConsole Self-Test ===');
-  Writeln(Format('Server: http://127.0.0.1:%d/%s', [GPort, cAPI_PREFIX]));
-  Writeln('');
-  _RunDemoProductScenarios;
-  _RunDemoReadOnlyScenarios;
-  _RunDemoGetOnlyScenarios;
-  _RunDemoGetPostScenarios;
-  Writeln('');
-  Writeln(Format('Result: %d/%d passed', [GPassCount, cSCENARIOS_TOTAL]));
-end;
-
-var
-  LFDConn: TFDConnection;
-  LConnection: IDBConnection;
-  LHorseFDConn: TFDConnection;
-  LHorseConn: IDBConnection;
-  LServer: TRESTServerHorse;
-  LOldRoutes: THorseRouterTree;
-  LNewRoutes: THorseRouterTree;
-begin
-  IsMultiThread := True;
-  FDManager.SilentMode := True;
-  Randomize;
-  GPort := 9200 + Random(100);
-  GPassCount := 0;
-  GFailCount := 0;
-  System.ExitCode := EXIT_FAILURE;
-  try
-    LFDConn := TFDConnection.Create(nil);
-    LFDConn.Params.DriverID := 'SQLite';
-    LFDConn.Params.Database := cDB_PATH;
-    LFDConn.Params.Values['OpenMode'] := 'CreateUTF8';
-    LFDConn.Connected := True;
-    LConnection := TFactoryFireDAC.Create(LFDConn, dnSQLite);
-    LHorseFDConn := TFDConnection.Create(nil);
-    LHorseFDConn.Params.DriverID := 'SQLite';
-    LHorseFDConn.Params.Database := cDB_PATH;
-    LHorseFDConn.Params.Values['OpenMode'] := 'CreateUTF8';
-    LHorseFDConn.ResourceOptions.SilentMode := True;
-    LHorseFDConn.Connected := True;
-    LHorseConn := TFactoryFireDAC.Create(LHorseFDConn, dnSQLite);
-    _CreateSchema(LConnection);
-    _RegisterModels;
-    LServer := _StartServer(LHorseConn);
-    try
-      RunTests;
-      if GFailCount = 0 then
-        System.ExitCode := EXIT_SUCCESS;
-      Writeln('Server still running — press ENTER to exit');
-      Readln;
-    finally
-      THorse.StopListen;
-      LOldRoutes := THorse.Routes;
-      LNewRoutes := THorseRouterTree.Create;
-      THorse.Routes := LNewRoutes;
-      LOldRoutes.Free;
-      FreeAndNil(LServer);
-    end;
-    LHorseConn := nil;
-    LHorseFDConn.Connected := False;
-    FreeAndNil(LHorseFDConn);
-    LConnection := nil;
-    LFDConn.Connected := False;
-    FreeAndNil(LFDConn);
-  except
-    on E: Exception do
-    begin
-      Writeln(E.ClassName + ': ' + E.Message);
-      System.ExitCode := EXIT_FAILURE;
-    end;
-  end;
+  Writeln('=== JanusRESTHorseConsole ===');
+  Writeln(Format('Server running on http://127.0.0.1:%d/%s', [GPort, cAPI_PREFIX]));
+  Writeln('Press ENTER to exit...');
+  Readln;
+  THorse.StopListen;
+  LOldRoutes := THorse.Routes;
+  LNewRoutes := THorseRouterTree.Create;
+  THorse.Routes := LNewRoutes;
+  LOldRoutes.Free;
+  LProvider := nil;
   if TFile.Exists(cDB_PATH) then
     TFile.Delete(cDB_PATH);
 end.

--- a/Test/Delphi/JanusRESTHorseOracle.dpr
+++ b/Test/Delphi/JanusRESTHorseOracle.dpr
@@ -1,0 +1,95 @@
+program JanusRESTHorseOracle;
+
+{$IFNDEF TESTINSIGHT}
+{$APPTYPE CONSOLE}
+{$ENDIF}
+{$STRONGLINKTYPES ON}
+
+uses
+  System.Classes,
+  System.SysUtils,
+  System.IOUtils,
+  // FireDAC infrastructure
+  FireDAC.ConsoleUI.Wait,
+  FireDAC.Comp.Client,
+  // Oracle driver registration — initialization registers the OCI factory
+  FireDAC.Phys.Oracle,
+  FireDAC.Phys.OracleDef,
+  FireDAC.Stan.Def,
+  FireDAC.Stan.Intf,
+  FireDAC.Phys,
+  FireDAC.Stan.Async,
+  FireDAC.Comp.DataSet,
+  {$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX,
+  {$ENDIF}
+  DUnitX.TestFramework,
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  // Oracle DML generator — registers factory with TDriverRegister
+  Janus.DML.Generator.Oracle,
+  // Entity registration support
+  MetaDbDiff.Mapping.Register,
+  // Oracle test infrastructure
+  RestHorseOracleTest.Base in 'Tests\RestHorseOracleTest.Base.pas',
+  // Oracle auto-view test fixture
+  TestJanusRESTOracleAutoView in 'Tests\TestJanusRESTOracleAutoView.pas';
+
+const
+  EXIT_SUCCESS = 0;
+  EXIT_FAILURE = 1;
+
+var
+  LRunner: ITestRunner;
+  LResults: IRunResults;
+  LLogger: ITestLogger;
+  LNunitLogger: ITestLogger;
+  LXmlOutputFile: string;
+  LXmlDir: string;
+begin
+{$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX.RunRegisteredTests;
+  Exit;
+{$ENDIF}
+  System.ExitCode := EXIT_FAILURE;
+  IsMultiThread := True;
+  FDManager.SilentMode := True;
+  try
+    TDUnitX.CheckCommandLine;
+    LXmlOutputFile := TDUnitX.Options.XMLOutputFile;
+    if LXmlOutputFile <> '' then
+    begin
+      LXmlOutputFile := TPath.GetFullPath(LXmlOutputFile);
+      LXmlDir := TPath.GetDirectoryName(LXmlOutputFile);
+      if (LXmlDir <> '') and (not TDirectory.Exists(LXmlDir)) then
+        TDirectory.CreateDirectory(LXmlDir);
+    end;
+    LRunner := TDUnitX.CreateRunner;
+    LLogger := TDUnitXConsoleLogger.Create(True);
+    LRunner.AddLogger(LLogger);
+    if LXmlOutputFile <> '' then
+      LNunitLogger := TDUnitXXMLNUnitFileLogger.Create(LXmlOutputFile)
+    else
+      LNunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    LRunner.AddLogger(LNunitLogger);
+    LRunner.FailsOnNoAsserts := False;
+    LResults := LRunner.Execute;
+    if not LResults.AllPassed then
+      System.ExitCode := EXIT_FAILURE
+    else
+      System.ExitCode := EXIT_SUCCESS;
+    {$IFNDEF CI}
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done.. press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+  except
+    on E: Exception do
+    begin
+      System.Writeln(E.ClassName, ': ', E.Message);
+      System.ExitCode := EXIT_FAILURE;
+    end;
+  end;
+end.

--- a/Test/Delphi/JanusSmoke.dpr
+++ b/Test/Delphi/JanusSmoke.dpr
@@ -1,4 +1,4 @@
-program JanusSmoke;
+﻿program JanusSmoke;
 
 {$IFNDEF TESTINSIGHT}
 {$APPTYPE CONSOLE}
@@ -47,7 +47,9 @@ uses
   TestDMLGenerator in 'Tests\TestDMLGenerator.pas',
   TestFluentSQLIntegration in 'Tests\TestFluentSQLIntegration.pas',
   /// REST/Horse Tests — ESP-002
-  TestJanusRESTQueryParse in 'Tests\TestJanusRESTQueryParse.pas';
+  TestJanusRESTQueryParse in 'Tests\TestJanusRESTQueryParse.pas',
+  /// LiveBindings R22.1 Tests — ESP-004
+  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/JanusSmoke.dpr
+++ b/Test/Delphi/JanusSmoke.dpr
@@ -49,7 +49,9 @@ uses
   /// REST/Horse Tests — ESP-002
   TestJanusRESTQueryParse in 'Tests\TestJanusRESTQueryParse.pas',
   /// LiveBindings R22.1 Tests — ESP-004
-  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas';
+  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas',
+  /// LiveBindings R22.2 Tests — ESP-004
+  Tests.Janus.LiveBindings.R222 in 'Tests\Tests.Janus.LiveBindings.R222.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/JanusSmoke.dpr
+++ b/Test/Delphi/JanusSmoke.dpr
@@ -47,11 +47,7 @@ uses
   TestDMLGenerator in 'Tests\TestDMLGenerator.pas',
   TestFluentSQLIntegration in 'Tests\TestFluentSQLIntegration.pas',
   /// REST/Horse Tests — ESP-002
-  TestJanusRESTQueryParse in 'Tests\TestJanusRESTQueryParse.pas',
-  /// LiveBindings R22.1 Tests — ESP-004
-  Tests.Janus.LiveBindings.R221 in 'Tests\Tests.Janus.LiveBindings.R221.pas',
-  /// LiveBindings R22.2 Tests — ESP-004
-  Tests.Janus.LiveBindings.R222 in 'Tests\Tests.Janus.LiveBindings.R222.pas';
+  TestJanusRESTQueryParse in 'Tests\TestJanusRESTQueryParse.pas';
 
 const
   EXIT_SUCCESS = 0;

--- a/Test/Delphi/JanusSmoke.dproj
+++ b/Test/Delphi/JanusSmoke.dproj
@@ -1,0 +1,206 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ProjectGuid>{F84FEA1F-CC54-4EEE-84B0-74EFF0DD1C72}</ProjectGuid>
+        <MainSource>JanusSmoke.dpr</MainSource>
+        <Base>True</Base>
+        <Config Condition="'$(Config)'==''">Debug</Config>
+        <ProjectName Condition="'$(ProjectName)'==''">JanusSmoke</ProjectName>
+        <TargetedPlatforms>660609</TargetedPlatforms>
+        <AppType>Console</AppType>
+        <FrameworkType>None</FrameworkType>
+        <ProjectVersion>20.4</ProjectVersion>
+        <Platform Condition="'$(Platform)'==''">Win32</Platform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Base' or '$(Base)'!=''">
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Android' and '$(Base)'=='true') or '$(Base_Android)'!=''">
+        <Base_Android>true</Base_Android>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice32' and '$(Base)'=='true') or '$(Base_iOSDevice32)'!=''">
+        <Base_iOSDevice32>true</Base_iOSDevice32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSDevice64' and '$(Base)'=='true') or '$(Base_iOSDevice64)'!=''">
+        <Base_iOSDevice64>true</Base_iOSDevice64>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='iOSSimulator' and '$(Base)'=='true') or '$(Base_iOSSimulator)'!=''">
+        <Base_iOSSimulator>true</Base_iOSSimulator>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="('$(Platform)'=='Win32' and '$(Base)'=='true') or '$(Base_Win32)'!=''">
+        <Base_Win32>true</Base_Win32>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Release' or '$(Cfg_1)'!=''">
+        <Cfg_1>true</Cfg_1>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Config)'=='Debug' or '$(Cfg_2)'!=''">
+        <Cfg_2>true</Cfg_2>
+        <CfgParent>Base</CfgParent>
+        <Base>true</Base>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base)'!=''">
+        <DCC_E>false</DCC_E>
+        <DCC_F>false</DCC_F>
+        <DCC_K>false</DCC_K>
+        <DCC_N>false</DCC_N>
+        <DCC_S>false</DCC_S>
+        <DCC_ImageBase>00400000</DCC_ImageBase>
+        <SanitizedProjectName>JanusSmoke</SanitizedProjectName>
+        <VerInfo_Locale>1046</VerInfo_Locale>
+        <VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=1.0.0.0;Comments=;CFBundleName=</VerInfo_Keys>
+        <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
+        <DCC_UnitSearchPath>D:\Ecossistema-Delphi\Janus\Source\Livebindings;D:\Ecossistema-Delphi\Janus\Source\Core;D:\Ecossistema-Delphi\Janus\Source\Middleware;D:\Ecossistema-Delphi\Janus\Source\Middleware-Horse;D:\Ecossistema-Delphi\Janus\Source\CodeGen;D:\Ecossistema-Delphi\Janus\Source\RESTful\Server;D:\Ecossistema-Delphi\Janus\Source\RESTful\Common;D:\Ecossistema-Delphi\Janus\Source\RESTful\Client;D:\Ecossistema-Delphi\Janus\Source\Dataset;D:\Ecossistema-Delphi\Janus\Source\Objectset;D:\Ecossistema-Delphi\Janus\Source\Metadata;D:\Ecossistema-Delphi\Janus\Source\Monitor;D:\Ecossistema-Delphi\Janus\Source\External\SQLite3;D:\Ecossistema-Delphi\Janus\Source\Dependencies\MetaDbDiff\Source\Core;D:\Ecossistema-Delphi\Janus\Source\Dependencies\MetaDbDiff\Source\Drivers;D:\Ecossistema-Delphi\Janus\Source\Dependencies\FluentSQL\Source\Core;D:\Ecossistema-Delphi\Janus\Source\Dependencies\FluentSQL\Source\Drivers;D:\Ecossistema-Delphi\Janus\Source\Dependencies\DataEngine\Source\Core;D:\Ecossistema-Delphi\Janus\Source\Dependencies\DataEngine\Source\Drivers;D:\Ecossistema-Delphi\Janus\Source\Dependencies\DataEngine\Source\External\SQLite3;D:\Ecossistema-Delphi\Janus\Source\Dependencies\DataEngine\Source\Integrations;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Core;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\JSON\Core;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\JSON\IO;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\JSON\Composition;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\JSON\Middleware;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Reader;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Writer;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Addons\Composition;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Addons\Validation;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Schema\Core;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Schema\IO;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Schema\Composition;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Schema\Validators;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Schema\Validators\Format;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Schema\Validators\Format\Brazil;D:\Ecossistema-Delphi\Janus\Source\Dependencies\JsonFlow\Source\Middleware-Horse;D:\Ecossistema-Delphi\Janus\Source\Dependencies\ModernSyntax\Source;D:\Ecossistema-Delphi\Janus\Source\Dependencies\Horse\src;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
+        <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Android)'!=''">
+        <Android_LauncherIcon36>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_36x36.png</Android_LauncherIcon36>
+        <Android_LauncherIcon48>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_48x48.png</Android_LauncherIcon48>
+        <Android_LauncherIcon72>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_72x72.png</Android_LauncherIcon72>
+        <Android_LauncherIcon96>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_96x96.png</Android_LauncherIcon96>
+        <Android_LauncherIcon144>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_144x144.png</Android_LauncherIcon144>
+        <Android_SplashImage426>$(BDS)\bin\Artwork\Android\FM_SplashImage_426x320.png</Android_SplashImage426>
+        <Android_SplashImage470>$(BDS)\bin\Artwork\Android\FM_SplashImage_470x320.png</Android_SplashImage470>
+        <Android_SplashImage640>$(BDS)\bin\Artwork\Android\FM_SplashImage_640x480.png</Android_SplashImage640>
+        <Android_SplashImage960>$(BDS)\bin\Artwork\Android\FM_SplashImage_960x720.png</Android_SplashImage960>
+        <AUP_ACCESS_COARSE_LOCATION>true</AUP_ACCESS_COARSE_LOCATION>
+        <AUP_ACCESS_FINE_LOCATION>true</AUP_ACCESS_FINE_LOCATION>
+        <AUP_CALL_PHONE>true</AUP_CALL_PHONE>
+        <AUP_CAMERA>true</AUP_CAMERA>
+        <AUP_INTERNET>true</AUP_INTERNET>
+        <AUP_READ_CALENDAR>true</AUP_READ_CALENDAR>
+        <AUP_READ_EXTERNAL_STORAGE>true</AUP_READ_EXTERNAL_STORAGE>
+        <AUP_WRITE_CALENDAR>true</AUP_WRITE_CALENDAR>
+        <AUP_WRITE_EXTERNAL_STORAGE>true</AUP_WRITE_EXTERNAL_STORAGE>
+        <AUP_READ_PHONE_STATE>true</AUP_READ_PHONE_STATE>
+        <Android_NotificationIcon24>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_24x24.png</Android_NotificationIcon24>
+        <Android_NotificationIcon36>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_36x36.png</Android_NotificationIcon36>
+        <Android_NotificationIcon48>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_48x48.png</Android_NotificationIcon48>
+        <Android_NotificationIcon72>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_72x72.png</Android_NotificationIcon72>
+        <Android_NotificationIcon96>$(BDS)\bin\Artwork\Android\FM_NotificationIcon_96x96.png</Android_NotificationIcon96>
+        <Android_LauncherIcon192>$(BDS)\bin\Artwork\Android\FM_LauncherIcon_192x192.png</Android_LauncherIcon192>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice32)'!=''">
+        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
+        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
+        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
+        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
+        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
+        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
+        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSDevice64)'!=''">
+        <iOS_AppStore1024>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_1024x1024.png</iOS_AppStore1024>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_iOSSimulator)'!=''">
+        <iPhone_AppIcon120>$(BDS)\bin\Artwork\iOS\iPhone\FM_ApplicationIcon_120x120.png</iPhone_AppIcon120>
+        <iPhone_Spotlight80>$(BDS)\bin\Artwork\iOS\iPhone\FM_SpotlightSearchIcon_80x80.png</iPhone_Spotlight80>
+        <iPhone_Notification40>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_40x40.png</iPhone_Notification40>
+        <iPhone_Notification60>$(BDS)\bin\Artwork\iOS\iPhone\FM_NotificationIcon_60x60.png</iPhone_Notification60>
+        <iPad_SpotLight80>$(BDS)\bin\Artwork\iOS\iPad\FM_SpotlightSearchIcon_80x80.png</iPad_SpotLight80>
+        <iPad_Notification40>$(BDS)\bin\Artwork\iOS\iPad\FM_NotificationIcon_40x40.png</iPad_Notification40>
+        <iPad_AppIcon152>$(BDS)\bin\Artwork\iOS\iPad\FM_ApplicationIcon_152x152.png</iPad_AppIcon152>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Base_Win32)'!=''">
+        <DCC_Namespace>Vcl;Vcl.Imaging;Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
+        <BT_BuildType>Debug</BT_BuildType>
+        <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.0.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=com.embarcadero.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.0.0.0;Comments=</VerInfo_Keys>
+        <VerInfo_Locale>1033</VerInfo_Locale>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_1)'!=''">
+        <DCC_Define>RELEASE;$(DCC_Define)</DCC_Define>
+        <DCC_DebugInformation>0</DCC_DebugInformation>
+        <DCC_LocalDebugSymbols>false</DCC_LocalDebugSymbols>
+        <DCC_SymbolReferenceInfo>0</DCC_SymbolReferenceInfo>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Cfg_2)'!=''">
+        <DCC_Define>DEBUG;$(DCC_Define)</DCC_Define>
+        <DCC_Optimize>false</DCC_Optimize>
+        <DCC_GenerateStackFrames>true</DCC_GenerateStackFrames>
+        <DCC_RangeChecking>true</DCC_RangeChecking>
+        <DCC_IntegerOverflowCheck>true</DCC_IntegerOverflowCheck>
+    </PropertyGroup>
+    <ItemGroup>
+        <DelphiCompile Include="$(MainSource)">
+            <MainSource>MainSource</MainSource>
+        </DelphiCompile>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Object Lazy\Model.Atendimento.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Object Lazy\Model.Exame.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Object Lazy\Model.Procedimento.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Object Lazy\Model.Setor.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Models\Janus.Model.Client.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Models\Janus.Model.Detail.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Models\Janus.Model.Lookup.pas"/>
+        <DCCReference Include="..\..\Examples\Delphi\Data\Models\Janus.Model.Master.pas"/>
+        <DCCReference Include="..\..\Source\Core\Janus.DML.Generator.SQLite.pas"/>
+        <DCCReference Include="Tests\TestMappingCache.pas"/>
+        <DCCReference Include="Tests\TestRttiSingleton.pas"/>
+        <DCCReference Include="Tests\TestNullable.pas"/>
+        <DCCReference Include="Tests\TestSmokeLazyLoading.pas"/>
+        <DCCReference Include="Tests\TestObjectSetLazyProxy.pas"/>
+        <DCCReference Include="Tests\TestLazyMapping.pas"/>
+        <DCCReference Include="Tests\TestLazyProxy.pas"/>
+        <DCCReference Include="Tests\TestDataSetLazyProxy.pas"/>
+        <DCCReference Include="Tests\TestRestLazyProxy.pas"/>
+        <DCCReference Include="Tests\TestLazyProxyMultiplicity.pas"/>
+        <DCCReference Include="Tests\TestLazyWrapper.pas"/>
+        <DCCReference Include="Tests\TestGetDictionary.pas"/>
+        <DCCReference Include="Tests\TestQueryCache.pas"/>
+        <DCCReference Include="Tests\TestDataSetAutoLazy.pas"/>
+        <DCCReference Include="Tests\TestCriteriaAdvanced.pas"/>
+        <DCCReference Include="Tests\TestMiddlewarePipeline.pas"/>
+        <DCCReference Include="Tests\TestDMLGenerator.pas"/>
+        <DCCReference Include="Tests\TestFluentSQLIntegration.pas"/>
+        <DCCReference Include="Tests\TestJanusRESTQueryParse.pas"/>
+        <BuildConfiguration Include="Base">
+            <Key>Base</Key>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Release">
+            <Key>Cfg_1</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+        <BuildConfiguration Include="Debug">
+            <Key>Cfg_2</Key>
+            <CfgParent>Base</CfgParent>
+        </BuildConfiguration>
+    </ItemGroup>
+    <ProjectExtensions>
+        <Borland.Personality>Delphi.Personality.12</Borland.Personality>
+        <Borland.ProjectType/>
+        <BorlandProject>
+            <Delphi.Personality>
+                <Source>
+                    <Source Name="MainSource">JanusSmoke.dpr</Source>
+                </Source>
+            </Delphi.Personality>
+            <Platforms>
+                <Platform value="Android">False</Platform>
+                <Platform value="iOSDevice32">False</Platform>
+                <Platform value="iOSDevice64">True</Platform>
+                <Platform value="iOSSimARM64">True</Platform>
+                <Platform value="iOSSimulator">False</Platform>
+                <Platform value="Linux64">True</Platform>
+                <Platform value="OSX32">False</Platform>
+                <Platform value="OSX64">True</Platform>
+                <Platform value="OSXARM64">True</Platform>
+                <Platform value="Win32">True</Platform>
+                <Platform value="Win64">False</Platform>
+                <Platform value="WinARM64EC">False</Platform>
+            </Platforms>
+        </BorlandProject>
+        <ProjectFileVersion>12</ProjectFileVersion>
+    </ProjectExtensions>
+    <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
+    <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+</Project>

--- a/Test/Delphi/Tests/JanusRESTHorseConsole.DataModule.dfm
+++ b/Test/Delphi/Tests/JanusRESTHorseConsole.DataModule.dfm
@@ -1,0 +1,24 @@
+object ProviderDM: TProviderDM
+  OldCreateOrder = False
+  Height = 214
+  Width = 341
+  object FDConnection1: TFDConnection
+    Params.Strings = (
+      'Database=janus_rest_console_test.db'
+      'LockingMode=Normal'
+      'OpenMode=CreateUTF8'
+      'DriverID=SQLite')
+    LoginPrompt = False
+    Left = 92
+    Top = 46
+  end
+  object FDGUIxWaitCursor1: TFDGUIxWaitCursor
+    Provider = 'Console'
+    Left = 148
+    Top = 126
+  end
+  object FDPhysSQLiteDriverLink1: TFDPhysSQLiteDriverLink
+    Left = 208
+    Top = 50
+  end
+end

--- a/Test/Delphi/Tests/JanusRESTHorseConsole.DataModule.pas
+++ b/Test/Delphi/Tests/JanusRESTHorseConsole.DataModule.pas
@@ -1,0 +1,29 @@
+unit JanusRESTHorseConsole.DataModule;
+
+interface
+
+uses
+  System.SysUtils, System.Classes,
+  FireDAC.Stan.Intf, FireDAC.Stan.Option, FireDAC.Stan.Error,
+  FireDAC.UI.Intf, FireDAC.Phys.Intf, FireDAC.Stan.Def,
+  FireDAC.Stan.Pool, FireDAC.Stan.Async, FireDAC.Phys,
+  FireDAC.Phys.SQLite, FireDAC.Phys.SQLiteDef, FireDAC.Stan.ExprFuncs,
+  FireDAC.ConsoleUI.Wait,
+  Data.DB, FireDAC.Comp.Client, FireDAC.Comp.UI;
+
+type
+  TProviderDM = class(TDataModule)
+    FDConnection1: TFDConnection;
+    FDGUIxWaitCursor1: TFDGUIxWaitCursor;
+    FDPhysSQLiteDriverLink1: TFDPhysSQLiteDriverLink;
+  private
+    { Private declarations }
+  public
+    { Public declarations }
+  end;
+
+implementation
+
+{$R *.dfm}
+
+end.

--- a/Test/Delphi/Tests/JanusRESTHorseConsole.Interfaces.pas
+++ b/Test/Delphi/Tests/JanusRESTHorseConsole.Interfaces.pas
@@ -1,0 +1,12 @@
+unit JanusRESTHorseConsole.Interfaces;
+
+interface
+
+type
+  IProvider = interface
+    ['{7A76F922-BB9C-47B4-8006-F3D564454F75}']
+  end;
+
+implementation
+
+end.

--- a/Test/Delphi/Tests/JanusRESTHorseConsole.Models.pas
+++ b/Test/Delphi/Tests/JanusRESTHorseConsole.Models.pas
@@ -1,0 +1,89 @@
+unit JanusRESTHorseConsole.Models;
+
+interface
+
+uses
+  DB,
+  MetaDbDiff.Types.Mapping,
+  MetaDbDiff.Mapping.Attributes;
+
+type
+  // No REST attribute — full CRUD allowed
+  [Entity]
+  [Table('demo_product', '')]
+  [PrimaryKey('id', 'Primary key')]
+  TDemoProduct = class
+  private
+    FId: Integer;
+    FName: String;
+    FPrice: Double;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+
+    [Column('price', ftFloat)]
+    property Price: Double read FPrice write FPrice;
+  end;
+
+  // RESTReadOnly — only GET allowed
+  [Entity]
+  [Table('demo_readonly', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTReadOnly]
+  TDemoReadOnly = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+  end;
+
+  // RESTAllowGET — GET only via grant
+  [Entity]
+  [Table('demo_get_only', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTAllowGET]
+  TDemoGetOnly = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+  end;
+
+  // RESTAllowGET + RESTAllowPOST — GET and POST allowed; PUT/DELETE blocked
+  [Entity]
+  [Table('demo_get_post', '')]
+  [PrimaryKey('id', 'Primary key')]
+  [RESTAllowGET]
+  [RESTAllowPOST]
+  TDemoGetPost = class
+  private
+    FId: Integer;
+    FName: String;
+  public
+    [Restrictions([NoUpdate, NotNull])]
+    [Column('id', ftInteger)]
+    property Id: Integer read FId write FId;
+
+    [Column('name', ftString, 100)]
+    property Name: String read FName write FName;
+  end;
+
+implementation
+
+end.

--- a/Test/Delphi/Tests/JanusRESTHorseConsole.Provider.pas
+++ b/Test/Delphi/Tests/JanusRESTHorseConsole.Provider.pas
@@ -1,0 +1,45 @@
+unit JanusRESTHorseConsole.Provider;
+
+interface
+
+uses
+  DataEngine.FactoryInterfaces,
+  DataEngine.FactoryFireDAC,
+  Janus.DML.Generator.SQLite,
+  Janus.Server.Horse,
+  JanusRESTHorseConsole.DataModule,
+  JanusRESTHorseConsole.Interfaces;
+
+type
+  TProviderJanus = class(TInterfacedObject, IProvider)
+  private
+    FRESTServerHorse: TRESTServerHorse;
+    FConnection: IDBConnection;
+    FProviderDM: TProviderDM;
+  protected
+  public
+    constructor Create;
+    destructor Destroy; override;
+  end;
+
+implementation
+
+{ TProviderJanus }
+
+constructor TProviderJanus.Create;
+begin
+  FProviderDM := TProviderDM.Create(nil);
+  // DataEngine Engine de Conexão a Banco de Dados
+  FConnection := TFactoryFireDAC.Create(FProviderDM.FDConnection1, dnSQLite);
+  // Janus - REST Server Horse
+  FRESTServerHorse := TRESTServerHorse.Create(nil, FConnection, 'api/Janus');
+end;
+
+destructor TProviderJanus.Destroy;
+begin
+  FProviderDM.Free;
+  FRESTServerHorse.Free;
+  inherited;
+end;
+
+end.

--- a/Test/Delphi/Tests/RestHorseOracleTest.Base.pas
+++ b/Test/Delphi/Tests/RestHorseOracleTest.Base.pas
@@ -1,0 +1,237 @@
+unit RestHorseOracleTest.Base;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  DUnitX.TestFramework,
+  DataEngine.FactoryInterfaces,
+  FireDAC.Comp.Client,
+  MetaDbDiff.Mapping.Register,
+  Janus.Server.Horse,
+  Horse;
+
+type
+  TRestHorseOracleTestBase = class
+  private
+    FDConnection: TFDConnection;
+    FConnection: IDBConnection;
+    FHorseDConnection: TFDConnection;
+    FHorseConnection: IDBConnection;
+    FServer: TRESTServerHorse;
+    FPort: Integer;
+    FServerThread: TThread;
+    procedure _StartHorse;
+    procedure _StopHorse;
+    procedure _RegisterOracleEntities;
+  protected
+    FPrefix: string;
+    property Connection: IDBConnection read FConnection;
+    property Port: Integer read FPort;
+    procedure SeedOracleData;
+    procedure DropView(const AViewName: string);
+    function BuildResourceURL(const AResource: string): string;
+    function ViewExists(const AViewName: string): Boolean;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+  end;
+
+implementation
+
+uses
+  DataEngine.FactoryFireDAC,
+  // FireDAC infrastructure units — required for Oracle driver registration.
+  // These units register drivers and UI providers in their initialization
+  // sections; no symbols are directly referenced in this file.
+  FireDAC.Stan.Def,
+  FireDAC.Stan.Intf,
+  FireDAC.Phys,
+  FireDAC.Phys.Oracle,
+  FireDAC.Phys.OracleDef,
+  FireDAC.ConsoleUI.Wait,
+  FireDAC.Stan.Async,
+  FireDAC.Comp.DataSet,
+  Horse.Core.RouterTree,
+  Janus.Oracle.Model.Cliente,
+  Janus.Oracle.Model.Produto,
+  Janus.Oracle.Model.Pedido,
+  Janus.Oracle.Model.PedidosCompletos,
+  Janus.DML.Generator.Oracle,
+  Janus.Server.RestView.Manager,
+  FluentSQL,
+  FluentSQL.Interfaces;
+
+{ TRestHorseOracleTestBase }
+
+procedure TRestHorseOracleTestBase._RegisterOracleEntities;
+var
+  LSelect: IFluentSQL;
+begin
+  TRegisterClass.RegisterEntity(TModelCliente);
+  TRegisterClass.RegisterEntity(TModelProduto);
+  TRegisterClass.RegisterEntity(TModelPedido);
+  TRegisterClass.RegisterEntity(TModelPedidosCompletos);
+  LSelect := FluentSQL.Query(dbnOracle)
+    .Select('p.id_pedido')
+    .Select('p.data_pedido')
+    .Select('c.id_cliente')
+    .Select('c.nome AS cliente_nome')
+    .Select('c.cidade AS cliente_cidade')
+    .Select('pr.id_produto')
+    .Select('pr.descricao AS produto_descricao')
+    .Select('pr.categoria AS produto_categoria')
+    .Select('pr.preco AS produto_preco')
+    .Select('p.quantidade')
+    .Select('p.valor_total')
+    .From('pedidos p')
+    .InnerJoin('clientes c')
+    .OnCond('c.id_cliente = p.id_cliente')
+    .InnerJoin('produtos pr')
+    .OnCond('pr.id_produto = p.id_produto');
+  TRESTViewManager.Register(TModelPedidosCompletos,
+    function: IFluentSQL
+    begin
+      Result := LSelect;
+    end);
+end;
+
+procedure TRestHorseOracleTestBase._StartHorse;
+begin
+  FPort := 9700 + Random(100);
+  FServer := TRESTServerHorse.Create(nil, FHorseConnection, FPrefix);
+  FServerThread := TThread.CreateAnonymousThread(
+    procedure
+    begin
+      THorse.Listen(FPort);
+    end);
+  FServerThread.FreeOnTerminate := False;
+  FServerThread.Start;
+  Sleep(200);
+end;
+
+procedure TRestHorseOracleTestBase._StopHorse;
+begin
+  THorse.StopListen;
+  if Assigned(FServerThread) then
+  begin
+    FServerThread.Terminate;
+    FServerThread.WaitFor;
+    FreeAndNil(FServerThread);
+  end;
+  FreeAndNil(FServer);
+end;
+
+procedure TRestHorseOracleTestBase.SeedOracleData;
+begin
+  FDConnection.ExecSQL(
+    'MERGE INTO clientes c ' +
+    'USING DUAL ON (c.id_cliente = 1) ' +
+    'WHEN NOT MATCHED THEN INSERT (id_cliente, nome, email, cidade, data_cadastro) ' +
+    'VALUES (1, ''Cliente Teste'', ''teste@teste.com'', ''Sao Paulo'', SYSDATE)');
+  FDConnection.ExecSQL(
+    'MERGE INTO produtos p ' +
+    'USING DUAL ON (p.id_produto = 1) ' +
+    'WHEN NOT MATCHED THEN INSERT (id_produto, descricao, preco, categoria) ' +
+    'VALUES (1, ''Produto Teste'', 99.99, ''Categoria A'')');
+  FDConnection.ExecSQL(
+    'MERGE INTO pedidos p ' +
+    'USING DUAL ON (p.id_pedido = 1) ' +
+    'WHEN NOT MATCHED THEN INSERT (id_pedido, id_cliente, id_produto, quantidade, valor_total, data_pedido) ' +
+    'VALUES (1, 1, 1, 2, 199.98, SYSDATE)');
+end;
+
+procedure TRestHorseOracleTestBase.DropView(const AViewName: string);
+begin
+  FDConnection.ExecSQL(
+    'BEGIN EXECUTE IMMEDIATE ''DROP VIEW ' + AViewName + '''; ' +
+    'EXCEPTION WHEN OTHERS THEN NULL; END;');
+end;
+
+function TRestHorseOracleTestBase.BuildResourceURL(const AResource: string): string;
+begin
+  if FPrefix <> '' then
+    Result := Format('http://127.0.0.1:%d/%s/%s', [FPort, FPrefix, AResource])
+  else
+    Result := Format('http://127.0.0.1:%d/%s', [FPort, AResource]);
+end;
+
+function TRestHorseOracleTestBase.ViewExists(const AViewName: string): Boolean;
+var
+  LQuery: TFDQuery;
+begin
+  LQuery := TFDQuery.Create(nil);
+  try
+    LQuery.Connection := FDConnection;
+    LQuery.SQL.Text :=
+      'SELECT COUNT(1) FROM user_views WHERE view_name = UPPER(:VNAME)';
+    LQuery.ParamByName('VNAME').AsString := AViewName;
+    LQuery.Open;
+    Result := LQuery.Fields[0].AsInteger > 0;
+  finally
+    LQuery.Free;
+  end;
+end;
+
+procedure TRestHorseOracleTestBase.SetupFixture;
+begin
+  Randomize;
+  FDConnection := TFDConnection.Create(nil);
+  FDConnection.Params.DriverID := 'Ora';
+  FDConnection.Params.Values['Server'] := 'localhost';
+  FDConnection.Params.Values['Port'] := '1521';
+  FDConnection.Params.Values['Database'] := 'XE';
+  FDConnection.Params.Values['User_Name'] := 'LOCAL';
+  FDConnection.Params.Values['Password'] := 'local';
+  FDConnection.Connected := True;
+  FConnection := TFactoryFireDAC.Create(FDConnection, dnOracle);
+  FHorseDConnection := TFDConnection.Create(nil);
+  FHorseDConnection.Params.DriverID := 'Ora';
+  FHorseDConnection.Params.Values['Server'] := 'localhost';
+  FHorseDConnection.Params.Values['Port'] := '1521';
+  FHorseDConnection.Params.Values['Database'] := 'XE';
+  FHorseDConnection.Params.Values['User_Name'] := 'LOCAL';
+  FHorseDConnection.Params.Values['Password'] := 'local';
+  FHorseDConnection.Connected := True;
+  FHorseConnection := TFactoryFireDAC.Create(FHorseDConnection, dnOracle);
+  _RegisterOracleEntities;
+  _StartHorse;
+end;
+
+procedure TRestHorseOracleTestBase.TearDownFixture;
+var
+  LOldRoutes: THorseRouterTree;
+  LNewRoutes: THorseRouterTree;
+begin
+  _StopHorse;
+  LOldRoutes := THorse.Routes;
+  LNewRoutes := THorseRouterTree.Create;
+  THorse.Routes := LNewRoutes;
+  LOldRoutes.Free;
+  TRESTViewManager.ClearCache;
+  FHorseConnection := nil;
+  FHorseDConnection.Connected := False;
+  FreeAndNil(FHorseDConnection);
+  FConnection := nil;
+  FDConnection.Connected := False;
+  FreeAndNil(FDConnection);
+end;
+
+procedure TRestHorseOracleTestBase.Setup;
+begin
+  // intentionally empty — override in subclasses if per-test setup is needed
+end;
+
+procedure TRestHorseOracleTestBase.TearDown;
+begin
+  // intentionally empty — override in subclasses if per-test teardown is needed
+end;
+
+end.

--- a/Test/Delphi/Tests/TestJanusRESTOracleAutoView.pas
+++ b/Test/Delphi/Tests/TestJanusRESTOracleAutoView.pas
@@ -1,0 +1,146 @@
+unit TestJanusRESTOracleAutoView;
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  Net.HTTPClient,
+  Net.URLClient,
+  DUnitX.TestFramework,
+  RestHorseOracleTest.Base;
+
+type
+  [TestFixture]
+  TTestOracleAutoView = class(TRestHorseOracleTestBase)
+  private
+    FHTTPClient: THTTPClient;
+    function _BuildURL(const AResource: string; const AQuery: string = ''): string;
+    function _Get(const AURL: string): string;
+    function _Post(const AURL: string; const ABody: string): string;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [Setup]
+    procedure Setup;
+    [TearDown]
+    procedure TearDown;
+
+    [Test]
+    procedure GetAutoView_ViewNotExisting_ServerCreatesViewAndReturnsData;
+    [Test]
+    procedure GetAutoView_ViewAlreadyExists_SkipsDDLAndReturnsData;
+    [Test]
+    procedure PostAutoView_Blocked_ReturnsReadOnlyError;
+    [Test]
+    procedure GetAutoView_WithFilter_ReturnsFilteredData;
+  end;
+
+implementation
+
+uses
+  Janus.Server.RestView.Manager;
+
+const
+  cREADONLY_MSG = 'read-only (RESTReadOnly)';
+
+{ TTestOracleAutoView }
+
+procedure TTestOracleAutoView.SetupFixture;
+begin
+  FPrefix := 'api/Janus';
+  inherited SetupFixture;
+end;
+
+procedure TTestOracleAutoView.Setup;
+begin
+  FHTTPClient := THTTPClient.Create;
+  FHTTPClient.ConnectionTimeout := 5000;
+  FHTTPClient.ResponseTimeout := 5000;
+  DropView('vw_pedidos_completos');
+  TRESTViewManager.ClearCache;
+  SeedOracleData;
+end;
+
+procedure TTestOracleAutoView.TearDown;
+begin
+  FreeAndNil(FHTTPClient);
+end;
+
+function TTestOracleAutoView._BuildURL(const AResource: string;
+  const AQuery: string): string;
+begin
+  Result := BuildResourceURL(AResource);
+  if AQuery <> '' then
+    Result := Result + '?' + AQuery;
+end;
+
+function TTestOracleAutoView._Get(const AURL: string): string;
+begin
+  Result := FHTTPClient.Get(AURL).ContentAsString(TEncoding.UTF8);
+end;
+
+function TTestOracleAutoView._Post(const AURL: string;
+  const ABody: string): string;
+var
+  LStream: TStringStream;
+begin
+  LStream := TStringStream.Create(ABody, TEncoding.UTF8);
+  try
+    Result := FHTTPClient.Post(AURL, LStream, nil,
+      [TNameValuePair.Create('Content-Type', 'application/json')])
+      .ContentAsString(TEncoding.UTF8);
+  finally
+    LStream.Free;
+  end;
+end;
+
+procedure TTestOracleAutoView.GetAutoView_ViewNotExisting_ServerCreatesViewAndReturnsData;
+var
+  LResult: string;
+begin
+  // Pre: DropView + ClearCache in Setup — view does not exist
+  LResult := _Get(_BuildURL('modelpedidoscompletos'));
+  Assert.IsFalse(LResult.Contains('"exception"'),
+    'GET auto-view returned exception: ' + LResult);
+  Assert.IsTrue(ViewExists('vw_pedidos_completos'),
+    'View was not created by the server');
+end;
+
+procedure TTestOracleAutoView.GetAutoView_ViewAlreadyExists_SkipsDDLAndReturnsData;
+var
+  LResult: string;
+begin
+  // Pre: first GET creates and caches the view
+  _Get(_BuildURL('modelpedidoscompletos'));
+  // Second GET — uses cache (no DDL)
+  LResult := _Get(_BuildURL('modelpedidoscompletos'));
+  Assert.IsFalse(LResult.Contains('"exception"'),
+    'Second GET returned exception: ' + LResult);
+end;
+
+procedure TTestOracleAutoView.PostAutoView_Blocked_ReturnsReadOnlyError;
+var
+  LResult: string;
+begin
+  // Ensure view exists so request reaches the read-only check
+  _Get(_BuildURL('modelpedidoscompletos'));
+  LResult := _Post(_BuildURL('modelpedidoscompletos'), '{"id_pedido":999}');
+  Assert.Contains(LResult, cREADONLY_MSG,
+    'POST on view must return read-only error, got: ' + LResult);
+end;
+
+procedure TTestOracleAutoView.GetAutoView_WithFilter_ReturnsFilteredData;
+var
+  LResult: string;
+begin
+  _Get(_BuildURL('modelpedidoscompletos')); // ensure view exists
+  LResult := _Get(_BuildURL('modelpedidoscompletos', '$filter=id_pedido eq 1'));
+  Assert.IsFalse(LResult.Contains('"exception"'),
+    'Filtered GET returned exception: ' + LResult);
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(TTestOracleAutoView);
+
+end.

--- a/Test/Delphi/Tests/Tests.Janus.LiveBindings.R221.pas
+++ b/Test/Delphi/Tests/Tests.Janus.LiveBindings.R221.pas
@@ -1,0 +1,196 @@
+{ @abstract(Janus R22.1 LiveBindings DUnitX fixture)
+  @created(23 Apr 2026)
+  Covers CA-001, CA-002, CA-004, CA-008.
+}
+
+unit Tests.Janus.LiveBindings.R221;
+
+interface
+
+{$IFDEF DCC}
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  System.SysUtils,
+  Vcl.Forms,
+  Vcl.StdCtrls,
+  Janus.Binder.Attributes,
+  Janus.Binder.Resolver,
+  Janus.Binder;
+
+type
+  TTestPersonR221 = class
+  private
+    FNome: string;
+    FIdade: Integer;
+  published
+    [Bind('EditNome', 'Text')]
+    property Nome: string read FNome write FNome;
+    [Bind('EditIdade', 'Text')]
+    property Idade: Integer read FIdade write FIdade;
+  end;
+
+  [TestFixture]
+  TTestJanusBinderR221 = class
+  private
+    FForm: TForm;
+    FEditNome: TEdit;
+    FEditIdade: TEdit;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+
+    [Test]
+    procedure TestBind_SimpleControl_TwoWaySync;
+    [Test]
+    procedure TestBind_TwoOwners_NoGlobalStateCollision;
+    [Test]
+    procedure TestResolver_FindComponent_ByName;
+    [Test]
+    procedure TestDestroy_FreesAllLinkComponents;
+  end;
+
+{$ENDIF DCC}
+
+implementation
+
+{$IFDEF DCC}
+
+{ TTestJanusBinderR221 }
+
+procedure TTestJanusBinderR221.SetupFixture;
+begin
+  FForm := TForm.Create(nil);
+  FForm.Name := 'TestForm';
+  FEditNome := TEdit.Create(FForm);
+  FEditNome.Name := 'EditNome';
+  FEditNome.Parent := FForm;
+  FEditIdade := TEdit.Create(FForm);
+  FEditIdade.Name := 'EditIdade';
+  FEditIdade.Parent := FForm;
+end;
+
+procedure TTestJanusBinderR221.TearDownFixture;
+begin
+  FreeAndNil(FForm);
+end;
+
+procedure TTestJanusBinderR221.TestBind_SimpleControl_TwoWaySync;
+var
+  LPerson: TTestPersonR221;
+  LBinder: TJanusBinder;
+  LEdit: TEdit;
+begin
+  LPerson := TTestPersonR221.Create;
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LPerson.Nome := 'Alice';
+    LBinder.Bind(LPerson);
+    LEdit := FForm.FindComponent('EditNome') as TEdit;
+    Assert.IsNotNull(LEdit, 'EditNome must exist on form');
+    Assert.AreEqual('Alice', LEdit.Text, 'Initial bind: entity -> control');
+    LPerson.Nome := 'Bob';
+    LBinder.Refresh;
+    Assert.AreEqual('Bob', LEdit.Text, 'After refresh: entity change -> control');
+  finally
+    LBinder.Free;
+    LPerson.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR221.TestBind_TwoOwners_NoGlobalStateCollision;
+var
+  LForm1, LForm2: TForm;
+  LEdit1, LEdit2: TEdit;
+  LEditIdade1, LEditIdade2: TEdit;
+  LPerson1, LPerson2: TTestPersonR221;
+  LBinder1, LBinder2: TJanusBinder;
+begin
+  LForm1 := TForm.Create(nil);
+  LForm2 := TForm.Create(nil);
+  LEdit1 := TEdit.Create(LForm1);
+  LEdit2 := TEdit.Create(LForm2);
+  LEditIdade1 := TEdit.Create(LForm1);
+  LEditIdade2 := TEdit.Create(LForm2);
+  LPerson1 := TTestPersonR221.Create;
+  LPerson2 := TTestPersonR221.Create;
+  LBinder1 := TJanusBinder.Create(LForm1);
+  LBinder2 := TJanusBinder.Create(LForm2);
+  try
+    LEdit1.Name := 'EditNome';
+    LEdit1.Parent := LForm1;
+    LEdit2.Name := 'EditNome';
+    LEdit2.Parent := LForm2;
+    LEditIdade1.Name := 'EditIdade';
+    LEditIdade1.Parent := LForm1;
+    LEditIdade2.Name := 'EditIdade';
+    LEditIdade2.Parent := LForm2;
+    LPerson1.Nome := 'Alice';
+    LPerson2.Nome := 'Bob';
+    LBinder1.Bind(LPerson1);
+    LBinder2.Bind(LPerson2);
+    Assert.AreEqual('Alice', LEdit1.Text, 'Form1 EditNome must show Alice');
+    Assert.AreEqual('Bob',   LEdit2.Text, 'Form2 EditNome must show Bob');
+    Assert.AreNotEqual(LEdit1.Text, LEdit2.Text, 'No shared state between binders');
+  finally
+    LBinder2.Free;
+    LBinder1.Free;
+    LPerson2.Free;
+    LPerson1.Free;
+    LForm2.Free;
+    LForm1.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR221.TestResolver_FindComponent_ByName;
+var
+  LForm: TForm;
+  LEdit: TEdit;
+  LFound: TComponent;
+begin
+  LForm := TForm.Create(nil);
+  LEdit := TEdit.Create(LForm);
+  try
+    LEdit.Name := 'LookupTarget';
+    LEdit.Parent := LForm;
+    LFound := TJanusBinderResolver.Resolve(LForm, 'LookupTarget');
+    Assert.IsNotNull(LFound, 'Resolve must find existing component');
+    Assert.AreSame(LEdit, LFound, 'Resolved component must be the TEdit');
+    LFound := TJanusBinderResolver.Resolve(LForm, 'NonExistent');
+    Assert.IsNull(LFound, 'Resolve must return nil for missing name');
+  finally
+    LForm.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR221.TestDestroy_FreesAllLinkComponents;
+var
+  LPerson: TTestPersonR221;
+  LBinder: TJanusBinder;
+begin
+  LPerson := TTestPersonR221.Create;
+  try
+    LPerson.Nome := 'Alice';
+    LBinder := TJanusBinder.Create(FForm);
+    LBinder.Bind(LPerson);
+    Assert.WillNotRaiseAny(
+      procedure begin
+        LBinder.Free;
+      end,
+      'TJanusBinder.Destroy must free all owned links without error');
+  finally
+    LPerson.Free;
+  end;
+end;
+
+{$ENDIF DCC}
+
+initialization
+{$IFDEF DCC}
+  TDUnitX.RegisterTestFixture(TTestJanusBinderR221);
+{$ENDIF}
+
+end.

--- a/Test/Delphi/Tests/Tests.Janus.LiveBindings.R222.pas
+++ b/Test/Delphi/Tests/Tests.Janus.LiveBindings.R222.pas
@@ -1,0 +1,368 @@
+{ @abstract(Janus R22.2 LiveBindings DUnitX fixture)
+  @created(24 Apr 2026)
+  Covers CA-001..CA-010 including R22.1 control->entity gap (CA-008).
+}
+
+unit Tests.Janus.LiveBindings.R222;
+
+interface
+
+{$IFDEF DCC}
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  System.SysUtils,
+  System.Rtti,
+  System.Generics.Collections,
+  Data.Bind.ObjectScope,
+  Data.Bind.Components,
+  Data.Bind.EngExt,
+  Vcl.Forms,
+  Vcl.StdCtrls,
+  Vcl.Grids,
+  Vcl.Bind.Grid,
+  Vcl.Bind.Editors,
+  Janus.Binder.Attributes,
+  Janus.Binder;
+
+type
+  TTestProduct = class
+  private
+    FCode: Integer;
+    FName: string;
+  published
+    property Code: Integer read FCode write FCode;
+    property Name: string read FName write FName;
+  end;
+
+  TTestOrder = class
+  private
+    FOrderId: Integer;
+    FProductCode: Integer;
+  published
+    property OrderId: Integer read FOrderId write FOrderId;
+    property ProductCode: Integer read FProductCode write FProductCode;
+  end;
+
+  TTestOrderLine = class
+  private
+    FLineId: Integer;
+    FQty: Integer;
+  published
+    property LineId: Integer read FLineId write FLineId;
+    property Qty: Integer read FQty write FQty;
+  end;
+
+  TTestProductBindable = class
+  private
+    FCodeStr: string;
+  published
+    [Bind('EditCode', 'Text')]
+    property CodeStr: string read FCodeStr write FCodeStr;
+  end;
+
+  [TestFixture]
+  TTestJanusBinderR222 = class
+  private
+    FForm: TForm;
+    FGridProducts: TStringGrid;
+    FGridOrders: TStringGrid;
+    FGridLines: TStringGrid;
+    FEditCode: TEdit;
+    FProducts: TObjectList<TTestProduct>;
+    FOrders0: TObjectList<TTestOrder>;
+    FOrders1: TObjectList<TTestOrder>;
+    FLines0: TObjectList<TTestOrderLine>;
+    function _GetOrders(const AMaster: TTestProduct): TObjectList<TTestOrder>;
+    function _GetLines(const ADetail: TTestOrder): TObjectList<TTestOrderLine>;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+
+    [Test]
+    procedure TestBindGrid_AdapterHasCorrectRowCount;
+    [Test]
+    procedure TestBindGrid_GridNotFound_RaisesException;
+    [Test]
+    procedure TestMasterDetail_Scroll_UpdatesDetailCount;
+    [Test]
+    procedure TestMasterDetail_EmptyMaster_NoException;
+    [Test]
+    procedure TestMasterDetailSubdetail_Scroll_UpdatesSubdetailCount;
+    [Test]
+    procedure TestDestroy_FreesAllGridComponents;
+    [Test]
+    procedure TestBind_R221Regression_StillWorks;
+    [Test]
+    procedure TestBind_ControlToEntity_Sync;
+    [Test]
+    procedure TestTwoBinders_SameGridName_IndependentWiring;
+  end;
+
+{$ENDIF DCC}
+
+implementation
+
+{$IFDEF DCC}
+
+{ TTestJanusBinderR222 }
+
+function TTestJanusBinderR222._GetOrders(
+  const AMaster: TTestProduct): TObjectList<TTestOrder>;
+begin
+  if AMaster.Code = 1 then
+    Result := FOrders0
+  else
+    Result := FOrders1;
+end;
+
+function TTestJanusBinderR222._GetLines(
+  const ADetail: TTestOrder): TObjectList<TTestOrderLine>;
+begin
+  Result := FLines0;
+end;
+
+procedure TTestJanusBinderR222.SetupFixture;
+var
+  LP0, LP1: TTestProduct;
+  LO0, LO1, LO2, LO3: TTestOrder;
+  LLine0, LLine1: TTestOrderLine;
+begin
+  FForm := TForm.Create(nil);
+  FForm.Name := 'TestFormR222';
+
+  FGridProducts := TStringGrid.Create(FForm);
+  FGridProducts.Name := 'GridProducts';
+  FGridProducts.Parent := FForm;
+
+  FGridOrders := TStringGrid.Create(FForm);
+  FGridOrders.Name := 'GridOrders';
+  FGridOrders.Parent := FForm;
+
+  FGridLines := TStringGrid.Create(FForm);
+  FGridLines.Name := 'GridLines';
+  FGridLines.Parent := FForm;
+
+  FEditCode := TEdit.Create(FForm);
+  FEditCode.Name := 'EditCode';
+  FEditCode.Parent := FForm;
+
+  FProducts := TObjectList<TTestProduct>.Create(True);
+  LP0 := TTestProduct.Create; LP0.Code := 1; LP0.Name := 'Widget'; FProducts.Add(LP0);
+  LP1 := TTestProduct.Create; LP1.Code := 2; LP1.Name := 'Gadget'; FProducts.Add(LP1);
+
+  FOrders0 := TObjectList<TTestOrder>.Create(True);
+  LO0 := TTestOrder.Create; LO0.OrderId := 10; LO0.ProductCode := 1; FOrders0.Add(LO0);
+  LO1 := TTestOrder.Create; LO1.OrderId := 11; LO1.ProductCode := 1; FOrders0.Add(LO1);
+  LO2 := TTestOrder.Create; LO2.OrderId := 12; LO2.ProductCode := 1; FOrders0.Add(LO2);
+
+  FOrders1 := TObjectList<TTestOrder>.Create(True);
+  LO3 := TTestOrder.Create; LO3.OrderId := 20; LO3.ProductCode := 2; FOrders1.Add(LO3);
+
+  FLines0 := TObjectList<TTestOrderLine>.Create(True);
+  LLine0 := TTestOrderLine.Create; LLine0.LineId := 100; LLine0.Qty := 5; FLines0.Add(LLine0);
+  LLine1 := TTestOrderLine.Create; LLine1.LineId := 101; LLine1.Qty := 3; FLines0.Add(LLine1);
+end;
+
+procedure TTestJanusBinderR222.TearDownFixture;
+begin
+  FreeAndNil(FLines0);
+  FreeAndNil(FOrders1);
+  FreeAndNil(FOrders0);
+  FreeAndNil(FProducts);
+  FreeAndNil(FForm);
+end;
+
+procedure TTestJanusBinderR222.TestBindGrid_AdapterHasCorrectRowCount;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindGrid<TTestProduct>(FProducts, 'GridProducts');
+    Assert.AreEqual(2, LBinder.GridBindSources[0].Adapter.ItemCount,
+      'Adapter item count must equal list count (CA-001)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestBindGrid_GridNotFound_RaisesException;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    Assert.WillRaise(
+      procedure
+      begin
+        LBinder.BindGrid<TTestProduct>(FProducts, 'NonExistentGrid');
+      end,
+      EJanusBinderException,
+      'BindGrid with unknown grid name must raise EJanusBinderException (CA-002)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestMasterDetail_Scroll_UpdatesDetailCount;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindMasterDetail<TTestProduct, TTestOrder>(
+      FProducts, 'GridProducts', _GetOrders, 'GridOrders');
+    LBinder.GridBindSources[0].Next;
+    Assert.AreEqual(1, LBinder.GridBindSources[1].Adapter.ItemCount,
+      'After master scroll to product[1] detail count must be 1 (CA-003)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestMasterDetail_EmptyMaster_NoException;
+var
+  LBinder: TJanusBinder;
+  LEmptyList: TObjectList<TTestProduct>;
+begin
+  LEmptyList := TObjectList<TTestProduct>.Create(False);
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindMasterDetail<TTestProduct, TTestOrder>(
+      LEmptyList, 'GridProducts', _GetOrders, 'GridOrders');
+    Assert.AreEqual(0, LBinder.GridBindSources[0].Adapter.ItemCount,
+      'Master grid must show 0 rows for empty list (CA-004)');
+  finally
+    LBinder.Free;
+    LEmptyList.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestMasterDetailSubdetail_Scroll_UpdatesSubdetailCount;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindMasterDetailSubdetail<TTestProduct, TTestOrder, TTestOrderLine>(
+      FProducts, 'GridProducts', _GetOrders, 'GridOrders', _GetLines, 'GridLines');
+    LBinder.GridBindSources[0].Next;    // master → product[1], detail → FOrders1 (1 order)
+    LBinder.GridBindSources[0].Prior;   // master → product[0], detail → FOrders0 (3 orders)
+    LBinder.GridBindSources[1].First;   // detail → order[0], subdetail → FLines0 (2 lines)
+    Assert.AreEqual(2, LBinder.GridBindSources[2].Adapter.ItemCount,
+      'Subdetail adapter count must be 2 after scrolling to order[0] (CA-005)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestDestroy_FreesAllGridComponents;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  LBinder.BindGrid<TTestProduct>(FProducts, 'GridProducts');
+  Assert.WillNotRaiseAny(
+    procedure
+    begin
+      LBinder.Free;
+    end,
+    'TJanusBinder.Destroy after BindGrid must not raise (CA-006)');
+end;
+
+procedure TTestJanusBinderR222.TestBind_R221Regression_StillWorks;
+var
+  LBinder: TJanusBinder;
+  LProduct: TTestProduct;
+begin
+  LProduct := TTestProduct.Create;
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LProduct.Code := 99;
+    Assert.WillNotRaiseAny(
+      procedure
+      begin
+        LBinder.Bind(LProduct);
+        LBinder.Refresh;
+      end,
+      'R22.1 TJanusBinder.Bind must remain functional after R22.2 extension (CA-007)');
+  finally
+    LBinder.Free;
+    LProduct.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestBind_ControlToEntity_Sync;
+var
+  LBinder: TJanusBinder;
+  LProduct: TTestProductBindable;
+  LField: TBindSourceAdapterField;
+begin
+  LProduct := TTestProductBindable.Create;
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LProduct.CodeStr := 'Alice';
+    LBinder.Bind(LProduct);
+    Assert.AreEqual('Alice', FEditCode.Text,
+      'Initial bind must sync entity->control (CA-008a)');
+    // CA-008b: control->entity sync. In a headless console test the Windows
+    // message loop is not running, so EN_CHANGE notifications from TEdit are
+    // never dispatched to TLinkPropertyToField. Instead we drive the same
+    // underlying mechanism: adapter Edit/SetTValue/Post propagates to the entity
+    // exactly as TLinkPropertyToField would at runtime.
+    LBinder.Adapter.Edit;
+    LField := LBinder.Adapter.Adapter.FindField('CodeStr');
+    Assert.IsNotNull(LField, 'Adapter must expose CodeStr field (CA-008b)');
+    LField.SetTValue(TValue.From<string>('Bob'));
+    LBinder.Adapter.Post;
+    Assert.AreEqual('Bob', LProduct.CodeStr,
+      'Adapter edit/post must propagate field value to entity property (CA-008b)');
+  finally
+    LBinder.Free;
+    LProduct.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR222.TestTwoBinders_SameGridName_IndependentWiring;
+var
+  LForm2: TForm;
+  LGrid2: TStringGrid;
+  LBinder1, LBinder2: TJanusBinder;
+  LProducts2: TObjectList<TTestProduct>;
+  LP: TTestProduct;
+begin
+  LForm2 := TForm.Create(nil);
+  LGrid2 := TStringGrid.Create(LForm2);
+  LGrid2.Name := 'GridProducts';
+  LGrid2.Parent := LForm2;
+  LProducts2 := TObjectList<TTestProduct>.Create(True);
+  LP := TTestProduct.Create; LP.Code := 99; LP.Name := 'Solo'; LProducts2.Add(LP);
+  LBinder1 := TJanusBinder.Create(FForm);
+  LBinder2 := TJanusBinder.Create(LForm2);
+  try
+    LBinder1.BindGrid<TTestProduct>(FProducts, 'GridProducts');
+    LBinder2.BindGrid<TTestProduct>(LProducts2, 'GridProducts');
+    Assert.AreEqual(2, LBinder1.GridBindSources[0].Adapter.ItemCount,
+      'Binder1 must show 2 rows for FProducts');
+    Assert.AreEqual(1, LBinder2.GridBindSources[0].Adapter.ItemCount,
+      'Binder2 must show 1 row independently (CA-009)');
+  finally
+    LBinder2.Free;
+    LBinder1.Free;
+    LProducts2.Free;
+    LForm2.Free;
+  end;
+end;
+
+{$ENDIF DCC}
+
+initialization
+{$IFDEF DCC}
+  TDUnitX.RegisterTestFixture(TTestJanusBinderR222);
+{$ENDIF}
+
+end.

--- a/Test/Delphi/Tests/Tests.Janus.LiveBindings.R223.pas
+++ b/Test/Delphi/Tests/Tests.Janus.LiveBindings.R223.pas
@@ -1,0 +1,296 @@
+{ @abstract(Janus R22.3 LiveBindings DUnitX fixture — DataSet backend)
+  @created(25 Apr 2026)
+  Covers CA-001..CA-008, CA-010: TBindSourceDB wiring, master-detail, Unbind, Destroy, regression.
+}
+
+unit Tests.Janus.LiveBindings.R223;
+
+interface
+
+{$IFDEF DCC}
+
+uses
+  DUnitX.TestFramework,
+  System.Classes,
+  System.SysUtils,
+  System.Generics.Collections,
+  Data.DB,
+  Data.Bind.Components,
+  Data.Bind.DBLinks,
+  Vcl.Forms,
+  Vcl.StdCtrls,
+  Vcl.Grids,
+  Vcl.Bind.Grid,
+  Vcl.Bind.Editors,
+  FireDAC.Comp.Client,
+  FireDAC.Stan.Intf,
+  FireDAC.Stan.Def,
+  FireDAC.Phys,
+  FireDAC.Phys.SQLite,
+  FireDAC.Phys.SQLiteDef,
+  FireDAC.ConsoleUI.Wait,
+  FireDAC.Comp.DataSet,
+  Janus.Binder.Attributes,
+  Janus.Binder;
+
+type
+  TLocalProduct = class
+  private
+    FCode: Integer;
+    FName: string;
+  published
+    property Code: Integer read FCode write FCode;
+    property Name: string read FName write FName;
+  end;
+
+  [TestFixture]
+  TTestJanusBinderR223 = class
+  private
+    FForm: TForm;
+    FGridProducts: TStringGrid;
+    FGridOrders: TStringGrid;
+    FGridLines: TStringGrid;
+    FEditName: TEdit;
+    FMemProducts: TFDMemTable;
+    FMemOrders: TFDMemTable;
+    FMemLines: TFDMemTable;
+    FProducts: TObjectList<TLocalProduct>;
+  public
+    [SetupFixture]
+    procedure SetupFixture;
+    [TearDownFixture]
+    procedure TearDownFixture;
+
+    [Test]
+    procedure TestBindDataSetGrid_SourceActiveAndWired;
+    [Test]
+    procedure TestBindDataSetGrid_GridNotFound_Raises;
+    [Test]
+    procedure TestBindDataSetGrid_NotAGrid_Raises;
+    [Test]
+    procedure TestBindDataSetMasterDetail_TwoSourcesWired;
+    [Test]
+    procedure TestBindDataSetMasterDetailSubdetail_ThreeSources;
+    [Test]
+    procedure TestUnbind_ClearsDataSetCollections;
+    [Test]
+    procedure TestDestroy_NoAVAfterBindDataSetGrid;
+    [Test]
+    procedure TestR222Regression_ObjectBackendUnchanged;
+  end;
+
+{$ENDIF DCC}
+
+implementation
+
+{$IFDEF DCC}
+
+{ TTestJanusBinderR223 }
+
+procedure TTestJanusBinderR223.SetupFixture;
+var
+  LP0, LP1: TLocalProduct;
+begin
+  FForm := TForm.Create(nil);
+  FForm.Name := 'TestFormR223';
+
+  FGridProducts := TStringGrid.Create(FForm);
+  FGridProducts.Name := 'GridProducts';
+  FGridProducts.Parent := FForm;
+
+  FGridOrders := TStringGrid.Create(FForm);
+  FGridOrders.Name := 'GridOrders';
+  FGridOrders.Parent := FForm;
+
+  FGridLines := TStringGrid.Create(FForm);
+  FGridLines.Name := 'GridLines';
+  FGridLines.Parent := FForm;
+
+  FEditName := TEdit.Create(FForm);
+  FEditName.Name := 'EditName';
+  FEditName.Parent := FForm;
+
+  FMemProducts := TFDMemTable.Create(nil);
+  FMemProducts.FieldDefs.Add('Id', ftInteger);
+  FMemProducts.FieldDefs.Add('Name', ftString, 50);
+  FMemProducts.CreateDataSet;
+  FMemProducts.AppendRecord([1, 'Widget']);
+  FMemProducts.AppendRecord([2, 'Gadget']);
+  FMemProducts.AppendRecord([3, 'Doohickey']);
+  FMemProducts.Active := True;
+
+  FMemOrders := TFDMemTable.Create(nil);
+  FMemOrders.FieldDefs.Add('Id', ftInteger);
+  FMemOrders.FieldDefs.Add('OrderRef', ftString, 20);
+  FMemOrders.CreateDataSet;
+  FMemOrders.AppendRecord([10, 'ORD-A']);
+  FMemOrders.AppendRecord([11, 'ORD-B']);
+  FMemOrders.Active := True;
+
+  FMemLines := TFDMemTable.Create(nil);
+  FMemLines.FieldDefs.Add('Id', ftInteger);
+  FMemLines.FieldDefs.Add('Qty', ftInteger);
+  FMemLines.CreateDataSet;
+  FMemLines.AppendRecord([100, 5]);
+  FMemLines.Active := True;
+
+  FProducts := TObjectList<TLocalProduct>.Create(True);
+  LP0 := TLocalProduct.Create; LP0.Code := 1; LP0.Name := 'Widget'; FProducts.Add(LP0);
+  LP1 := TLocalProduct.Create; LP1.Code := 2; LP1.Name := 'Gadget'; FProducts.Add(LP1);
+end;
+
+procedure TTestJanusBinderR223.TearDownFixture;
+begin
+  FreeAndNil(FMemLines);
+  FreeAndNil(FMemOrders);
+  FreeAndNil(FMemProducts);
+  FreeAndNil(FProducts);
+  FreeAndNil(FForm);
+end;
+
+procedure TTestJanusBinderR223.TestBindDataSetGrid_SourceActiveAndWired;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindDataSetGrid(FMemProducts, 'GridProducts');
+    Assert.AreEqual(1, LBinder.DBBindSources.Count,
+      'DBBindSources.Count must be 1 (CA-001a)');
+    Assert.IsTrue((LBinder.DBBindSources[0] as IScopeActive).Active,
+      'TBindSourceDB must be active (CA-001b)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR223.TestBindDataSetGrid_GridNotFound_Raises;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    Assert.WillRaise(
+      procedure
+      begin
+        LBinder.BindDataSetGrid(FMemProducts, 'NoSuchGrid');
+      end,
+      EJanusBinderException,
+      'Unknown grid must raise EJanusBinderException (CA-002)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR223.TestBindDataSetGrid_NotAGrid_Raises;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    Assert.WillRaise(
+      procedure
+      begin
+        LBinder.BindDataSetGrid(FMemProducts, 'EditName');
+      end,
+      EJanusBinderException,
+      'Non-grid control must raise EJanusBinderException (CA-003)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR223.TestBindDataSetMasterDetail_TwoSourcesWired;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindDataSetMasterDetail(
+      FMemProducts, 'GridProducts',
+      FMemOrders, 'GridOrders');
+    Assert.AreEqual(2, LBinder.DBBindSources.Count,
+      'DBBindSources.Count must be 2 (CA-004a)');
+    Assert.AreEqual(2, LBinder.GridLinks.Count,
+      'GridLinks.Count must be 2 (CA-004b)');
+    Assert.IsTrue((LBinder.DBBindSources[0] as IScopeActive).Active,
+      'Master TBindSourceDB must be active (CA-004c)');
+    Assert.IsTrue((LBinder.DBBindSources[1] as IScopeActive).Active,
+      'Detail TBindSourceDB must be active (CA-004d)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR223.TestBindDataSetMasterDetailSubdetail_ThreeSources;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindDataSetMasterDetailSubdetail(
+      FMemProducts, 'GridProducts',
+      FMemOrders, 'GridOrders',
+      FMemLines, 'GridLines');
+    Assert.AreEqual(3, LBinder.DBBindSources.Count,
+      'DBBindSources.Count must be 3 (CA-005)');
+    Assert.AreEqual(3, LBinder.GridLinks.Count,
+      'GridLinks.Count must be 3 (CA-005b)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR223.TestUnbind_ClearsDataSetCollections;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindDataSetGrid(FMemProducts, 'GridProducts');
+    LBinder.Unbind;
+    Assert.AreEqual(0, LBinder.DBBindSources.Count,
+      'DBBindSources must be empty after Unbind (CA-006a)');
+    Assert.AreEqual(0, LBinder.DataSources.Count,
+      'DataSources must be empty after Unbind (CA-006b)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+procedure TTestJanusBinderR223.TestDestroy_NoAVAfterBindDataSetGrid;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  LBinder.BindDataSetGrid(FMemProducts, 'GridProducts');
+  Assert.WillNotRaiseAny(
+    procedure
+    begin
+      LBinder.Free;
+    end,
+    'TJanusBinder.Destroy after BindDataSetGrid must not AV (CA-007)');
+end;
+
+procedure TTestJanusBinderR223.TestR222Regression_ObjectBackendUnchanged;
+var
+  LBinder: TJanusBinder;
+begin
+  LBinder := TJanusBinder.Create(FForm);
+  try
+    LBinder.BindGrid<TLocalProduct>(FProducts, 'GridProducts');
+    Assert.AreEqual(2, LBinder.GridBindSources[0].Adapter.ItemCount,
+      'Object backend BindGrid must still yield 2 rows after R22.3 extension (CA-008)');
+  finally
+    LBinder.Free;
+  end;
+end;
+
+{$ENDIF DCC}
+
+initialization
+{$IFDEF DCC}
+  TDUnitX.RegisterTestFixture(TTestJanusBinderR223);
+{$ENDIF}
+
+end.

--- a/docs-src/docs/janus/user/guides/livebindings.md
+++ b/docs-src/docs/janus/user/guides/livebindings.md
@@ -1,71 +1,207 @@
 ---
-title: Guia - LiveBindings (VCL e FMX)
+title: Guia - LiveBindings (VCL)
 displayed_sidebar: janusSidebar
 ---
 
-O Janus oferece atributos de LiveBindings para vincular propriedades de entidades a controles VCL/FMX automaticamente, sem código manual de binding.
+O Janus oferece um engine de LiveBindings (R22+) baseado em atributos e em `TJanusBinder` para vincular propriedades de entidades a controles VCL automaticamente, sem necessidade de código manual de binding, herança especial ou truques de ordenação no `uses`.
+
+## TJanusBinder
+
+O `TJanusBinder` é o ponto central do novo engine. Ele lê os atributos `[Bind]` da entidade via RTTI, cria os vínculos e mantém os controles sincronizados.
+
+Padrão de ciclo de vida:
+
+```delphi
+// FormCreate
+FBinder := TJanusBinder.Create(Self);
+FBinder.Bind(FEntidade);    // lê [Bind] via RTTI e cria os links
+FBinder.Refresh;            // propaga valores iniciais para os controles
+
+// FormDestroy
+FBinder.Free;               // antes de liberar a entidade
+```
+
+- `Bind(AEntity)` percorre as propriedades da entidade via RTTI e cria um `TLinkPropertyToField` por anotação `[Bind]` encontrada.
+- `Refresh` força a re-leitura do adapter e atualiza todos os controles. Chamar após alterações programáticas nas propriedades da entidade.
+- `FBinder` deve ser liberado antes da entidade que foi passada para `Bind`.
 
 ## Atributos disponíveis
 
 | Atributo | Uso |
 |----------|-----|
-| `[LiveBindingsControl('controle', 'campo')]` | Vincula uma propriedade a um controle pelo nome |
-| `[LiveBindingsGridMaster('grid')]` | Vincula a entidade como mestre de uma grade |
-| `[LiveBindingsGridDetail('grid', 'campoMestre')]` | Vincula como detalhe de uma grade |
+| `[Bind('controle', 'propriedade')]` | Vincula uma propriedade da entidade a uma propriedade do controle via `TLinkPropertyToField` |
+| `[BindGrid('grid')]` | Declara que a propriedade alimenta uma grade (chamada imperativa: `BindGrid<T>`) |
+| `[BindGridDetail('grid', 'propMestre')]` | Declara binding de detalhe (chamada imperativa: `BindMasterDetail<M,D>`) |
+| `[BindListControl('controle', 'campo')]` | Declara binding de lista (chamada imperativa: `BindList<T>`) |
+| `[BindGridColumn('título', largura, visível)]` | Metadados de coluna para uso com `ConfigureGridColumns` |
 
-## Incluir os controles estendidos
+:::note
+`[BindGrid]`, `[BindGridDetail]` e `[BindListControl]` são declarativos. O dispatch automático via RTTI (equivalente ao que `[Bind]` faz) está previsto para um ciclo futuro; por enquanto, use as chamadas imperativas correspondentes.
+:::
 
-Para VCL, inclua no uses do formulário:
+## Exemplo: controles simples (VCL)
 
-```delphi
-uses Janus.VCL.Controls;
-// O Janus redefine TEdit, TMaskEdit, TLabel, TComboBox, TMemo
-// com suporte automático a LiveBindings
-```
-
-Para FMX:
+Entidade (PODO — sem herança especial):
 
 ```delphi
-uses Janus.FMX.Controls;
-```
+unit produto;
 
-## Anotar a entidade
+interface
 
-```delphi
-[Entity]
-[Table('client', '')]
-Tclient = class
-private
-  Fclient_name: String;
-  Fclient_email: String;
-public
-  [Column('client_name', ftString, 40)]
-  [LiveBindingsControl('EditNome', 'Text')]
-  property client_name: String read Fclient_name write Fclient_name;
+uses
+  Janus.Binder.Attributes;
 
-  [Column('client_email', ftString, 100)]
-  [LiveBindingsControl('EditEmail', 'Text')]
-  property client_email: String read Fclient_email write Fclient_email;
-end;
-```
+type
+  TProduto = class
+  private
+    FID: Integer;
+    FPreco: Double;
+    FSoma: Double;
+    procedure SetID(const AValue: Integer);
+    procedure SetPreco(const AValue: Double);
+  public
+    [Bind('EditID', 'Text')]
+    [Bind('LabelID', 'Caption')]
+    property ID: Integer read FID write SetID;
 
-## Ativar o binding no formulário
+    [Bind('EditPreco', 'Text')]
+    property Preco: Double read FPreco write SetPreco;
 
-```delphi
-uses Janus.LiveBindings;
+    [Bind('EditSoma', 'Text')]  // campo computado: somente leitura
+    property Soma: Double read FSoma;
+  end;
 
-procedure TFormCliente.FormCreate(Sender: TObject);
-var LBindings: TJanusLivebindings;
+implementation
+
+procedure TProduto.SetID(const AValue: Integer);
 begin
-  LBindings := TJanusLivebindings.Create(Self);
-  LBindings.Bind(LClientEntity);
+  FID := AValue;
+  FSoma := FID * FPreco;  // recalcula campo derivado
+end;
+
+procedure TProduto.SetPreco(const AValue: Double);
+begin
+  FPreco := AValue;
+  FSoma := FID * FPreco;
+end;
+
+end.
+```
+
+Formulário (trecho):
+
+```delphi
+uses Janus.Binder;
+
+type
+  TFormPrincipal = class(TForm)
+    EditID: TEdit;
+    EditPreco: TEdit;
+    EditSoma: TEdit;    // somente leitura — campo computado
+    LabelID: TLabel;
+    BtnAtualizar: TButton;
+    procedure FormCreate(Sender: TObject);
+    procedure FormDestroy(Sender: TObject);
+    procedure BtnAtualizarClick(Sender: TObject);
+  private
+    FProduto: TProduto;
+    FBinder: TJanusBinder;
+  end;
+
+procedure TFormPrincipal.FormCreate(Sender: TObject);
+begin
+  FProduto := TProduto.Create;
+  FBinder := TJanusBinder.Create(Self);
+  FBinder.Bind(FProduto);
+  FProduto.ID := 1;
+  FProduto.Preco := 10;
+  FBinder.Refresh;          // exibe valores iniciais nos controles
+  EditSoma.ReadOnly := True; // campo derivado não deve ser editado pelo usuário
+end;
+
+procedure TFormPrincipal.FormDestroy(Sender: TObject);
+begin
+  FBinder.Free;    // libere o binder antes da entidade
+  FProduto.Free;
+end;
+
+procedure TFormPrincipal.BtnAtualizarClick(Sender: TObject);
+begin
+  FProduto.ID := FProduto.ID * 2;
+  FProduto.Preco := FProduto.Preco * 4.5;
+  FBinder.Refresh;  // propaga as alterações programáticas para os controles
 end;
 ```
 
-O Janus lê os atributos via RTTI e cria as expressões de binding automaticamente.
+## Exemplo: grade (VCL)
 
-## Dicas
+```delphi
+// Entidade com metadados de coluna
+type
+  TPedido = class
+  private
+    FId: Integer;
+    FDescricao: string;
+  published
+    [BindGridColumn('Código', 60)]
+    property Id: Integer read FId write FId;
 
-- Os nomes nos atributos devem corresponder exatamente ao nome do componente no formulário (`Name` do controle).
-- Para grades, use `[LiveBindingsGridMaster]` na entidade pai e `[LiveBindingsGridDetail]` na entidade filha.
-- Funciona com VCL e FMX sem alteração no code de negócio.
+    [BindGridColumn('Descrição', 200)]
+    property Descricao: string read FDescricao write FDescricao;
+  end;
+
+// No formulário
+var LPedidos: TObjectList<TPedido>;
+begin
+  LPedidos := // carregue a lista...
+  FBinder.BindGrid<TPedido>(LPedidos, 'GridPedidos');
+  FBinder.ConfigureGridColumns('GridPedidos', TPedido);
+end;
+```
+
+## Exemplo: controle de lista (VCL)
+
+```delphi
+FBinder.BindList<TPedido>(LPedidos, 'ListBoxPedidos', 'Descricao');
+```
+
+## Metadados de colunas com `[BindGridColumn]`
+
+Campos do atributo:
+
+- `ATitle: string` — título da coluna no cabeçalho da grade.
+- `AWidth: Integer` (padrão `-1`) — largura em pixels; `-1` mantém a largura padrão da grade.
+- `AVisible: Boolean` (padrão `True`) — se `False`, a coluna é omitida por `ConfigureGridColumns`.
+
+Fluxo de uso:
+
+1. Anote as propriedades `published` da entidade com `[BindGridColumn]`.
+2. Chame `FBinder.BindGrid<T>(lista, 'NomeDaGrade')` para criar o vínculo.
+3. Chame `FBinder.ConfigureGridColumns('NomeDaGrade', T)` para aplicar os metadados.
+
+:::note
+`ConfigureGridColumns` suporta `TStringGrid`. Grades do tipo `TDBGrid` ou de terceiros não são suportadas nesta versão.
+:::
+
+## Migração do engine legado
+
+:::caution Depreciação — remoção no R22.6
+Os seguintes símbolos foram marcados como `deprecated` no Janus R22.4 e serão **removidos no R22.6**:
+
+- `LiveBindingsControl`, `LiveBindingsGridMaster`, `LiveBindingsGridDetail` (em `Janus.LiveBindings`)
+- `TJanusLivebindings` (em `Janus.LiveBindings`)
+- `TListComponents`, `TListFieldNames`, `TListControls` (em `Janus.Controls.Helpers`)
+- As unidades `Janus.VCL.Controls` e `Janus.FMX.Controls` (engine de shadowing)
+:::
+
+**Passos de migração:**
+
+1. **Remova a herança.** Troque `TProduto = class(TJanusLiveBindings)` por `TProduto = class`.
+2. **Substitua os atributos.** Troque `[LiveBindingsControl('c', 'p')]` por `[Bind('c', 'p')]` de `Janus.Binder.Attributes`.
+3. **Elimine o `TBindings.Notify`.** Remova as chamadas `TBindings.Notify(Self, 'Campo')` dos setters. Para campos calculados (ex.: `Soma := ID * Preco`), compute o valor diretamente no setter.
+4. **Crie o binder no formulário.** Em `FormCreate`, crie um `TJanusBinder`, chame `Bind(entidade)` e `Refresh`. Em `FormDestroy`, libere o binder antes da entidade.
+5. **Remova `Janus.VCL.Controls` do `uses`.** Não é mais necessário posicioná-lo em último lugar.
+
+## FMX
+
+O `TJanusBinder` atual depende de unidades VCL (`Vcl.Controls`, `Vcl.Grids`). O suporte a projetos FMX — sem dependência de unidades VCL — requer suporte a compilação condicional por plataforma em `Janus.Binder.pas`, previsto para um ciclo futuro. Os exemplos FMX em `Examples/Delphi/Livebindings/FMX/` mantêm o engine legado com um aviso de migração.


### PR DESCRIPTION
## Batch release

Tasks included in this release:

- #152 feat(test/rest-horse-console): add zero-endpoint CRUD self-test console for TRESTServerHorse
- #153 feat(test/rest-horse-console): rewrite console to canonical TProviderJanus + TProviderDM pattern
- #154 feat(livebindings): introduce adapter-based TJanusBinder engine and Bind attribute DSL (R22.1)
- #155 feat(livebindings): wire BindGrid/MasterDetail/Subdetail grid engine and add R22.2 DUnitX fixture
- #156 fix(smoke): remove erroneous LiveBindings R22.1/R22.2 entries from JanusSmoke
- #157 feat(examples/oracle-rest): add Oracle REST Horse example with CRUD endpoints and view
- #158 feat(rest-autoview): add lazy-init view registry, implicit read-only guards, and Oracle DUnitX fixture
- #159 feat(livebindings): add DataSet backend to TJanusBinder with BindSourceDB wiring and R22.3 DUnitX fixture
- #161 docs(livebindings): rewrite user manual and migrate VCL example to TJanusBinder

Note: #160 (R22.4 Source/ Livebindings engine changes) is still in progress and not included in this batch.