### PR TITLE
fix(janus): PopularObjectSet infinite loop (missing cursor Next) + lazy-mapping cast

### DIFF
--- a/Source/Core/Janus.Mapping.Lazy.pas
+++ b/Source/Core/Janus.Mapping.Lazy.pas
@@ -282,12 +282,12 @@ begin
       if (LExistingIntf <> nil) and
          Supports(LExistingIntf, ILazyProxyResettable, LResettable) then
       begin
-        LResettable.Reset(ALoadFunc, AToken);
+        LResettable.Reset(TFunc<TObject>(ALoadFunc), AToken);
         Break;
       end;
     end;
 
-    LProxy := TLazyProxyLoader.Create(ALoadFunc, AToken);
+    LProxy := TLazyProxyLoader.Create(TFunc<TObject>(ALoadFunc), AToken);
     LRawPtr := Pointer(LProxy);
     TValue.Make(@LRawPtr, LFLazySubField.FieldType.Handle, LInterfaceValue);
     LFLazySubField.SetValue(LRecordPtr, LInterfaceValue);

--- a/Source/Core/Janus.Session.Abstract.pas
+++ b/Source/Core/Janus.Session.Abstract.pas
@@ -376,6 +376,9 @@ begin
       Bind.SetFieldToProperty(ADBResultSet, TObject(Result.Last));
       // Alimenta registros das associa��es existentes 1:1 ou 1:N
       FCommandExecutor.FillAssociation(Result.Last);
+      // Avan�a o cursor: sem isso o la�o nunca atinge Eof e popula a mesma
+      // linha infinitamente at� esgotar a heap (EOutOfMemory no binding).
+      ADBResultSet.Next;
     end;
     if Result.Count > 0 then
       Exit;


### PR DESCRIPTION
Two fixes that make Janus read against a standalone Firebird backend.

## 1. CRITICAL — `PopularObjectSet` never advances the cursor (infinite loop → OOM)
`Source/Core/Janus.Session.Abstract.pas` — the object-population loop
```pascal
while not ADBResultSet.Eof do
begin
  Result.Add(M.Create);
  Bind.SetFieldToProperty(ADBResultSet, TObject(Result.Last));
  FCommandExecutor.FillAssociation(Result.Last);
end;
```
**never calls `ADBResultSet.Next`**, so any `Find`/`FindWhere` over a non-empty result set loops infinitely, allocating entities until the heap is exhausted. It surfaces as a **non-deterministic** `Problem when binding column "X" - Out of memory` (the OOM tips over at a random allocation inside the binding). Fix: add `ADBResultSet.Next;`.

Verified end-to-end: `TManagerObjectSet.Find` reads all rows and a full lookup CRUD round-trip (FindAll/FindById/Insert/Update/Delete) is green against a live **Firebird 2.5** DB.

## 2. `Janus.Mapping.Lazy.pas` — E2010 cast
`TLazyLoadFunc` vs `TFunc<TObject>` (structurally identical reference-to-function types) — cast at the two proxy-loader call sites so the lazy-mapping chain compiles into a standalone/console build. Behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)