### PR TITLE
fix(association): advance the cursor in ExecuteOneToOne/ExecuteOneToMany (infinite loop)

### DIFF
--- a/Source/Core/Janus.Command.Executor.pas
+++ b/Source/Core/Janus.Command.Executor.pas
@@ -342,6 +342,9 @@ begin
       Bind.SetFieldToProperty(LResultSet, LObjectValue);
       // Alimenta registros das associa��es existentes 1:1 ou 1:N
       FillAssociation(LObjectValue);
+      // Avanca o cursor: sem isso o laco nunca atinge Eof e repopula o mesmo
+      // objeto infinitamente (loop infinito / hang).
+      LResultSet.Next;
     end;
   finally
     LResultSet.Close;
@@ -377,6 +380,9 @@ begin
       LObjectList := AProperty.GetNullableValue(AObject).AsObject;
       if LObjectList <> nil then
         LObjectList.MethodCall('Add', [LObjectCreate]);
+      // Avanca o cursor: sem isso o laco nunca atinge Eof e adiciona a mesma
+      // linha infinitamente (loop infinito / OOM).
+      LResultSet.Next;
     end;
   finally
     LResultSet.Close;


### PR DESCRIPTION
## What
`TSQLCommandExecutor.ExecuteOneToOne` and `ExecuteOneToMany` (the association-loading paths used by `FillAssociation`) both loop `while not LResultSet.Eof do ... SetFieldToProperty / FillAssociation [/ list.Add]` but **never call `LResultSet.Next`**. So populating ANY `[Association]` (OneToOne/ManyToOne or OneToMany/ManyToMany) over a non-empty result set loops **infinitely** — the process hangs (and the list variant grows unbounded → OOM).

This is the sibling of the `PopularObjectSet` missing-cursor fix; it only surfaces once an entity that actually declares an `[Association]` is read live (a lookup with no associations never reaches this code).

## Fix
Add `LResultSet.Next;` to both loops.

## Verified
A bespoke entity with a OneToOne `[Association]` (`P01` → `E12_FON`) now reads live end-to-end with the association object populated (Firebird 2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)