### PR TITLE
fix(dml): guard null FK in OneToOne/ManyToOne association SELECT (Firebird -104)

### DIFF
--- a/Source/Core/Janus.DML.Generator.pas
+++ b/Source/Core/Janus.DML.Generator.pas
@@ -152,6 +152,7 @@ var
   LOrderBy: TOrderByMapping;
   LOrderByList: TStringList;
   LFor: Integer;
+  LValue: Variant;
 begin
   if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
   begin
@@ -163,9 +164,16 @@ begin
   // Association Multi-Columns
   for LFor := 0 to AAssociation.ColumnsNameRef.Count -1 do
   begin
-    Result := Result + ' WHERE '
-                     + LTable.Name + '.' + AAssociation.ColumnsNameRef[LFor]
-                     + ' = ' + GetValue(LFor);
+    LValue := GetValue(LFor);
+    Result := Result + ifThen(LFor = 0, ' WHERE ', ' AND ');
+    // Guard de FK nula (associacao OneToOne/ManyToOne opcional): um RHS vazio
+    // gerava '... col = ' e estourava o Firebird (-104, fim inesperado de
+    // comando). '1 = 0' e SQL valido que casa zero linhas (sem pai/sem dono).
+    if VarIsNull(LValue) or VarIsEmpty(LValue) or (VarToStr(LValue) = '') then
+      Result := Result + '1 = 0'
+    else
+      Result := Result + LTable.Name + '.' + AAssociation.ColumnsNameRef[LFor]
+                       + ' = ' + VarToStr(LValue);
   end;
   // OrderBy
   LOrderBy := TMappingExplorer.GetMappingOrderBy(AClass);
@@ -209,6 +217,7 @@ var
   LOrderBy: TOrderByMapping;
   LOrderByList: TStringList;
   LFor: Integer;
+  LValue: Variant;
 begin
   if not FQueryCache.TryGetValue(AClass.ClassName, Result) then
   begin
@@ -220,10 +229,15 @@ begin
   // Association Multi-Columns
   for LFor := 0 to AAssociation.ColumnsNameRef.Count -1 do
   begin
+    LValue := GetValue(LFor);
     Result := Result + ifThen(LFor = 0, ' WHERE ', ' AND ');
-    Result := Result + LTable.Name
-                     + '.' + AAssociation.ColumnsNameRef[LFor]
-                     + ' = ' + GetValue(LFor)
+    // Guard de FK nula (associacao opcional): evita '... col = ' (FB -104).
+    if VarIsNull(LValue) or VarIsEmpty(LValue) or (VarToStr(LValue) = '') then
+      Result := Result + '1 = 0'
+    else
+      Result := Result + LTable.Name
+                       + '.' + AAssociation.ColumnsNameRef[LFor]
+                       + ' = ' + VarToStr(LValue);
   end;
   // OrderBy
   LOrderBy := TMappingExplorer.GetMappingOrderBy(AClass);


### PR DESCRIPTION
## Problem

`TDMLGeneratorAbstract.GenerateSelectOneToOne` / `GenerateSelectOneToOneMany` build the association SELECT by appending the owner's FK value into the `WHERE` clause **without a null guard**:

```pascal
Result := Result + ' WHERE ' + LTable.Name + '.' + AAssociation.ColumnsNameRef[LFor]
                 + ' = ' + GetValue(LFor);
```

For an **optional (nullable) OneToOne/ManyToOne** whose FK is `NULL` — e.g. a **root node of a self-referencing hierarchy** — `GetValue` returns a `Null` variant that renders as `''`, producing:

```
... WHERE MYTABLE.MY_FK =
```

Firebird rejects this with `SQL error code = -104 / Unexpected end of command`. Because the read path runs the association SELECT **per materialized row**, this breaks reads (and any DAO that reads before writing) for **any** entity with a nullable association as soon as one NULL-FK row exists.

## Fix

When the FK value is null/empty, emit `1 = 0` (valid SQL matching zero rows → "no parent/owner") instead of a dangling `col = `:

```pascal
LValue := GetValue(LFor);
Result := Result + ifThen(LFor = 0, ' WHERE ', ' AND ');
if VarIsNull(LValue) or VarIsEmpty(LValue) or (VarToStr(LValue) = '') then
  Result := Result + '1 = 0'
else
  Result := Result + LTable.Name + '.' + AAssociation.ColumnsNameRef[LFor]
                   + ' = ' + VarToStr(LValue);
```

Also:
- `GenerateSelectOneToOne` now uses `' WHERE '`/`' AND '` via `ifThen` for multi-column associations (it previously repeated `' WHERE '`), matching the `Many` variant.
- RHS uses `VarToStr` for an explicit, consistent conversion.

## Verification

Built and run live against **Firebird 2.5** through a consuming backend:
- Root rows (NULL FK) and child rows (non-null FK) both insert and read.
- `GET` by-id of a child resolves the full parent object.
- `GET` by-id of a root returns `parent = null` with no `-104`.
- Full consumer test suite: **2828/2828 green** (no regression).